### PR TITLE
feat: ros2 camera graph

### DIFF
--- a/docs/source/api/graphs.graph.rst
+++ b/docs/source/api/graphs.graph.rst
@@ -1,0 +1,7 @@
+Graph
+======
+
+.. automodule:: pegasus.simulator.logic.graphs.graph
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/graphs.ros2_camera.rst
+++ b/docs/source/api/graphs.ros2_camera.rst
@@ -1,0 +1,7 @@
+ROS2 Camera
+===========
+
+.. automodule:: pegasus.simulator.logic.graphs.ros2_camera
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -13,6 +13,15 @@ Sensors
    sensors.imu
    sensors.magnetometer
 
+Graphs
+------
+
+.. toctree::
+   :maxdepth: 2
+
+   graphs.graph
+   graphs.ros2_camera
+
 Dynamics
 --------
 

--- a/examples/8_camera_vehicle.py
+++ b/examples/8_camera_vehicle.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python
+"""
+| File: 8_camera_vehicle.py
+| License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto and Filip Stec. All rights reserved.
+| Description: This files serves as an example on how to build an app that makes use of the Pegasus API to run a simulation
+with a single vehicle equipped with a camera, producing rgb and camera info ROS2 topics.
+"""
+
+# Imports to start Isaac Sim from this script
+import carb
+from omni.isaac.kit import SimulationApp
+
+# Start Isaac Sim's simulation environment
+# Note: this simulation app must be instantiated right after the SimulationApp import, otherwise the simulator will crash
+# as this is the object that will load all the extensions and load the actual simulator.
+simulation_app = SimulationApp({"headless": False})
+
+# -----------------------------------
+# The actual script should start here
+# -----------------------------------
+import omni.timeline
+from omni.isaac.core.world import World
+from omni.isaac.core.utils.extensions import disable_extension, enable_extension
+
+# Enable/disable ROS bridge extensions to keep only ROS2 Bridge
+disable_extension("omni.isaac.ros_bridge")
+enable_extension("omni.isaac.ros2_bridge")
+
+# Import the Pegasus API for simulating drones
+from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
+from pegasus.simulator.logic.state import State
+from pegasus.simulator.logic.backends.mavlink_backend import MavlinkBackend, MavlinkBackendConfig
+from pegasus.simulator.logic.vehicles.multirotor import Multirotor, MultirotorConfig
+from pegasus.simulator.logic.interface.pegasus_interface import PegasusInterface
+from pegasus.simulator.logic.graphs import ROS2Camera
+
+# Auxiliary scipy and numpy modules
+from scipy.spatial.transform import Rotation
+
+class PegasusApp:
+    """
+    A Template class that serves as an example on how to build a simple Isaac Sim standalone App.
+    """
+
+    def __init__(self):
+        """
+        Method that initializes the PegasusApp and is used to setup the simulation environment.
+        """
+
+        # Acquire the timeline that will be used to start/stop the simulation
+        self.timeline = omni.timeline.get_timeline_interface()
+
+        # Start the Pegasus Interface
+        self.pg = PegasusInterface()
+
+        # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics,
+        # spawning asset primitives, etc.
+        self.pg._world = World(**self.pg._world_settings)
+        self.world = self.pg.world
+
+        # Launch one of the worlds provided by NVIDIA
+        self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
+
+        # Create the vehicle
+        # Try to spawn the selected robot in the world to the specified namespace
+        config_multirotor = MultirotorConfig()
+        # Create the multirotor configuration
+        mavlink_config = MavlinkBackendConfig({
+            "vehicle_id": 0,
+            "px4_autolaunch": True,
+            "px4_dir": "/home/marcelo/PX4-Autopilot",
+            "px4_vehicle_model": 'iris'
+        })
+        config_multirotor.backends = [MavlinkBackend(mavlink_config)]
+
+        # Create camera graph for the existing Camera prim on the Iris model, which can be found 
+        # at the prim path `/World/quadrotor/body/Camera`. The camera prim path is the local path from the vehicle's prim path
+        # to the camera prim, to which this graph will be connected. All ROS2 topics published by this graph will have 
+        # namespace `quadrotor` and frame_id `Camera` followed by the selected camera types (`rgb`, `camera_info`).
+        config_multirotor.graphs = [ROS2Camera("body/Camera", config={"types": ['rgb', 'camera_info']})]
+
+        Multirotor(
+            "/World/quadrotor",
+            ROBOTS['Iris'],
+            0,
+            [0.0, 0.0, 0.07],
+            Rotation.from_euler("XYZ", [0.0, 0.0, 0.0], degrees=True).as_quat(),
+            config=config_multirotor,
+        )
+
+        # Reset the simulation environment so that all articulations (aka robots) are initialized
+        self.world.reset()
+
+        # Auxiliar variable for the timeline callback example
+        self.stop_sim = False
+
+    def run(self):
+        """
+        Method that implements the application main loop, where the physics steps are executed.
+        """
+
+        # Start the simulation
+        self.timeline.play()
+
+        # The "infinite" loop
+        while simulation_app.is_running() and not self.stop_sim:
+            # Update the UI of the app and perform the physics step
+            self.world.step(render=True)
+
+        # Cleanup and stop
+        carb.log_warn("PegasusApp Simulation App is closing.")
+        self.timeline.stop()
+        simulation_app.close()
+
+def main():
+
+    # Instantiate the template app
+    pg_app = PegasusApp()
+
+    # Run the application loop
+    pg_app.run()
+
+if __name__ == "__main__":
+    main()

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
@@ -1,0 +1,6 @@
+"""
+| License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto and Filip Stec. All rights reserved.
+"""
+
+from .graph import Graph
+from .ros2_camera import ROS2Camera

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/graph.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/graph.py
@@ -1,0 +1,39 @@
+"""
+| License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto and Filip Stec. All rights reserved.
+"""
+__all__ = ["Graph"]
+
+class Graph:
+    """The base class for implementing OmniGraphs
+
+    Attributes:
+        graph_prim_path
+    """
+    def __init__(self, graph_type: str):
+        """Initialize Graph class
+
+        Args:
+            graph_type (str): A name that describes the type of graph
+        """
+        self._graph_type = graph_type
+        self._graph_prim_path = None
+
+    def initialize(self, graph_prim_path: str):
+        """
+        Method that should be implemented and called by the class that inherits the graph object.
+        """
+        self._graph_prim_path = graph_prim_path
+
+    @property
+    def graph_type(self) -> str:
+        """
+        (str) A name that describes the type of graph.
+        """
+        return self._graph_type
+
+    @property
+    def graph_prim_path(self) -> str:
+        """
+        (str) Path to the graph.
+        """
+        return self._graph_prim_path

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_camera.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_camera.py
@@ -1,0 +1,197 @@
+"""
+| File: ros2_camera.py
+| License: BSD-3-Clause. Copyright (c) 2023, Micah Nye. All rights reserved.
+"""
+__all__ = ["ROS2Camera"]
+
+import carb
+
+from omni.isaac.core.utils import stage
+import omni.graph.core as og
+from omni.isaac.core.utils.prims import is_prim_path_valid
+from omni.isaac.core.utils.prims import set_targets
+
+from pegasus.simulator.logic.graphs import Graph
+from pegasus.simulator.logic.vehicles import Vehicle
+import numpy as np
+
+class ROS2Camera(Graph):
+    """The class that implements the ROS2 Camera graph. This class inherits the base class Graph.
+    """
+    def __init__(self, camera_prim_path: str, config: dict = {}):
+        """Initialize the ROS2 Camera class
+
+        Args:
+            camera_prim_path (str): Path to the camera prim. Global path when it starts with `/`, else local to vehicle prim path
+            config (dict): A Dictionary that contains all the parameters for configuring the ROS2Camera - it can be empty or only have some of the parameters used by the ROS2Camera.
+
+        Examples:
+            The dictionary default parameters are
+
+            >>> {"graph_evaluator": "execution",            # type of the omnigraph to create (execution, push)
+            >>>  "resolution": [640, 480],                  # output video stream resolution in pixels [width, height]
+            >>>  "types": ['rgb', 'camera_info'],           # rgb, depth, depth_pcl, instance_segmentation, semantic_segmentation, bbox_2d_tight, bbox_2d_loose, bbox_3d, camera_info
+            >>>  "publish_labels": True}                    # publish labels for instance_segmentation, semantic_segmentation, bbox_2d_tight, bbox_2d_loose and bbox_3d camera types
+        """
+
+        # Initialize the Super class "object" attribute
+        super().__init__(graph_type="ROS2Camera")
+
+        # Save camera path, frame id and ros topic name
+        self._camera_prim_path = camera_prim_path
+        self._frame_id = camera_prim_path.rpartition("/")[-1] # frame_id of the camera is the last prim path part after `/`
+        self._base_topic = ""
+
+        # Process the config dictionary
+        self._graph_evaluator = config.get("graph_evaluator", "execution")
+        self._resolution = config.get("resolution", [640, 480])
+        self._types = np.array(config.get("types", ['rgb', 'camera_info']))
+        self._publish_labels = config.get("publish_labels", True)
+
+    def initialize(self, vehicle: Vehicle):
+        """Method that initializes the graph of the camera.
+
+        Args:
+            vehicle (Vehicle): The vehicle that this graph is attached to.
+        """
+
+        self._namespace = f"/{vehicle.vehicle_name}"
+        self._base_topic = f"/{self._frame_id}"
+
+        # Set the prim_path for the camera
+        if self._camera_prim_path[0] != '/':
+            self._camera_prim_path = f"{vehicle.prim_path}/{self._camera_prim_path}"
+
+        # Create camera prism
+        if not is_prim_path_valid(self._camera_prim_path):
+            carb.log_error(f"Cannot create ROS2 Camera graph, the camera prim path \"{self._camera_prim_path}\" is not valid")
+            return
+
+        # Set the prim paths for camera and tf graphs
+        graph_path = f"{self._camera_prim_path}_pub"
+
+        # Graph configuration
+        if self._graph_evaluator == "execution":
+            graph_specs = {
+                "graph_path": graph_path,
+                "evaluator_name": "execution",
+            }
+        elif self._graph_evaluator == "push":
+            graph_specs = {
+                "graph_path": graph_path,
+                "evaluator_name": "push",
+                "pipeline_stage": og.GraphPipelineStage.GRAPH_PIPELINE_STAGE_ONDEMAND,
+            }
+        else:
+            carb.log_error(f"Cannot create ROS2 Camera graph, graph evaluator type \"{self._graph_evaluator}\" is not valid")
+            return
+
+        # Creating a graph edit configuration with cameraHelper nodes to generate ROS image publishers
+        keys = og.Controller.Keys
+        graph_config = {
+            keys.CREATE_NODES: [
+                ("on_tick", "omni.graph.action.OnTick"),
+                ("create_viewport", "omni.isaac.core_nodes.IsaacCreateViewport"),
+                ("get_render_product", "omni.isaac.core_nodes.IsaacGetViewportRenderProduct"),
+                ("set_viewport_resolution", "omni.isaac.core_nodes.IsaacSetViewportResolution"),
+                ("set_camera", "omni.isaac.core_nodes.IsaacSetCameraOnRenderProduct"),
+            ],
+            keys.CONNECT: [
+                ("on_tick.outputs:tick", "create_viewport.inputs:execIn"),
+                ("create_viewport.outputs:execOut", "get_render_product.inputs:execIn"),
+                ("create_viewport.outputs:viewport", "get_render_product.inputs:viewport"),
+                ("create_viewport.outputs:execOut", "set_viewport_resolution.inputs:execIn"),
+                ("create_viewport.outputs:viewport", "set_viewport_resolution.inputs:viewport"),
+                ("set_viewport_resolution.outputs:execOut", "set_camera.inputs:execIn"),
+                ("get_render_product.outputs:renderProductPath", "set_camera.inputs:renderProductPath"),
+            ],
+            keys.SET_VALUES: [
+                ("create_viewport.inputs:viewportId", 0),
+                ("create_viewport.inputs:name", f"{self._namespace}/{self._frame_id}"),
+                ("set_viewport_resolution.inputs:width", self._resolution[0]),
+                ("set_viewport_resolution.inputs:height", self._resolution[1]),
+            ],
+        }
+
+        # Add camerasHelper for each selected camera type
+        valid_camera_type = False
+        for camera_type in self._types:
+            if not camera_type in ["rgb", "depth", "depth_pcl", "semantic_segmentation", "instance_segmentation", "bbox_2d_tight", "bbox_2d_loose", "bbox_3d", "camera_info"]:
+                continue
+
+            camera_helper_name = f"camera_helper_{camera_type}"
+
+            graph_config[keys.CREATE_NODES] += [
+                (camera_helper_name, "omni.isaac.ros2_bridge.ROS2CameraHelper")
+            ]
+            graph_config[keys.CONNECT] += [
+                ("set_camera.outputs:execOut", f"{camera_helper_name}.inputs:execIn"),
+                ("get_render_product.outputs:renderProductPath", f"{camera_helper_name}.inputs:renderProductPath")
+            ]
+            graph_config[keys.SET_VALUES] += [
+                (f"{camera_helper_name}.inputs:nodeNamespace", self._namespace),
+                (f"{camera_helper_name}.inputs:frameId", self._frame_id),
+                (f"{camera_helper_name}.inputs:topicName", f"{self._base_topic}/{camera_type}"),
+                (f"{camera_helper_name}.inputs:type", camera_type)
+            ]
+
+            # Publish labels for specific camera types
+            if self._publish_labels and camera_type in ["semantic_segmentation", "instance_segmentation", "bbox_2d_tight", "bbox_2d_loose", "bbox_3d"]:
+                graph_config[keys.SET_VALUES] += [
+                    (camera_helper_name + ".inputs:enableSemanticLabels", True),
+                    (camera_helper_name + ".inputs:semanticLabelsTopicName", f"{self._frame_id}/{camera_type}_labels")
+                ]
+
+            valid_camera_type = True
+
+        if not valid_camera_type:
+            carb.log_error(f"Cannot create ROS2 Camera graph, no valid camera type was selected")
+            return
+
+        # Create the camera graph
+        (graph, _, _, _) = og.Controller.edit(
+            graph_specs,
+            graph_config
+        )
+
+        # Connect camera to the graphs
+        set_targets(
+            prim=stage.get_current_stage().GetPrimAtPath(f"{graph_path}/set_camera"),
+            attribute="inputs:cameraPrim",
+            target_prim_paths=[self._camera_prim_path]
+        )
+
+        # Run the ROS Camera graph once to generate ROS image publishers in SDGPipeline
+        og.Controller.evaluate_sync(graph)
+
+        # Also initialize the Super class with updated prim path (only camera graph path)
+        super().initialize(graph_path)
+
+    def camera_topic(self, camera_type: str) -> str:
+        """
+        (str) Path to the camera topic.
+
+        Args:
+            camera_type (str): one of the supported camera output types
+
+        Returns:
+            Camera topic name (str) if the camera type exists, else empty string
+        """
+        return f"{self._namespace}{self._base_topic}/{camera_type}" if camera_type in self._types else ""
+
+    def camera_labels_topic(self, camera_type: str) -> str:
+        """
+        (str) Path to the camera labels topic.
+
+        Args:
+            camera_type (str): one of the supported camera output types
+
+        Returns:
+            Camera labels topic name (str) if the camera type exists, else empty string
+        """
+        if not self._publish_labels or \
+           not camera_type in self._types or \
+           not camera_type in ["semantic_segmentation", "instance_segmentation", "bbox_2d_tight", "bbox_2d_loose", "bbox_3d"]:
+            return ""
+
+        return f"{self._namespace}{self._base_topic}/{camera_type}_labels"

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
@@ -42,6 +42,9 @@ class MultirotorConfig:
         # The default sensors for a quadrotor
         self.sensors = [Barometer(), IMU(), Magnetometer(), GPS()]
 
+        # The default graphs
+        self.graphs = []
+
         # The backends for actually sending commands to the vehicle. By default use mavlink (with default mavlink configurations)
         # [Can be None as well, if we do not desired to use PX4 with this simulated vehicle]. It can also be a ROS2 backend
         # or your own custom Backend implementation!
@@ -85,12 +88,17 @@ class Multirotor(Vehicle):
         # and let the sensor decide depending on its internal update rate whether to generate new data
         self._world.add_physics_callback(self._stage_prefix + "/Sensors", self.update_sensors)
 
-        # 3. Setup the dynamics of the system
+        # 3. Initialize all the vehicle graphs
+        self._graphs = config.graphs
+        for graph in self._graphs:
+            graph.initialize(self)
+
+        # 4. Setup the dynamics of the system
         # Get the thrust curve of the vehicle from the configuration
         self._thrusters = config.thrust_curve
         self._drag = config.drag
 
-        # 4. Save the backend interface (if given in the configuration of the multirotor)
+        # 5. Save the backend interface (if given in the configuration of the multirotor)
         # and initialize them
         self._backends = config.backends
         for backend in self._backends:

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -71,6 +71,9 @@ class Vehicle(Robot):
         self._stage_prefix = get_stage_next_free_path(self._current_stage, stage_prefix, False)
         self._usd_file = usd_path
 
+        # Get the vehicle name by taking the last part of vehicle stage prefix
+        self._vehicle_name = self._stage_prefix.rpartition("/")[-1]
+
         # Spawn the vehicle primitive in the world's stage
         self._prim = define_prim(self._stage_prefix, "Xform")
         self._prim = get_prim_at_path(self._stage_prefix)
@@ -136,6 +139,15 @@ class Vehicle(Robot):
             State: The current state of the vehicle, i.e., position, orientation, linear and angular velocities...
         """
         return self._state
+    
+    @property
+    def vehicle_name(self) -> str:
+        """Vehicle name.
+
+        Returns:
+            Vehicle name (str): last prim name in vehicle prim path
+        """
+        return self._vehicle_name
 
     """
     Operations

--- a/extensions/pegasus.simulator/pegasus/simulator/parser/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/parser/__init__.py
@@ -7,3 +7,4 @@ from .sensor_parser import SensorParser
 from .thrusters_parser import ThrustersParser
 from .dynamics_parser import DynamicsParser
 from .backends_parser import BackendsParser
+from .graphs_parser import GraphParser

--- a/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
@@ -1,0 +1,25 @@
+# Copyright (c) 2023, Marcelo Jacinto
+# All rights reserved.
+#
+# SPDX-License-Identifier: BSD-3-Clause
+
+# Graphs that can be used with the vehicles
+from pegasus.simulator.parser import Parser
+from pegasus.simulator.logic.graphs import ROS2Camera
+
+
+class GraphParser(Parser):
+    def __init__(self):
+
+        # Dictionary of available graphs to instantiate
+        self.graphs = {
+            "ROS2 Camera": ROS2Camera
+        }
+
+    def parse(self, data_type: str, data_dict):
+
+        # Get the class of the graph
+        graph_cls = self.graphs[data_type]
+
+        # Create an instance of that graph
+        return graph_cls(data_dict)


### PR DESCRIPTION
Did a different take on the camera stream from the Isaac Sim using OmniGraphs. It uses ROS2Bridge extension, which seems to be built in C++, so it should be much better for camera data transmitting.

Created a new object class `Graph` for OmniGraphs, like this `ROS2Camera` graph. Therefore it does not create the camera sensor itself, only connects to an existing camera prim to set it up as a source for ROS2 camera topics. It uses ROS2 Camera Helper to setup the output topics. It also allows to specify camera types that will be published (rgb, depth, semantic segmentation, ...), so a camera helper will be created for each selected camera type.

The camera prim path can be local to the vehicle's prim path or global (starts with `/`). The last part of camera prim path is the camera frame id used for topics. Published topics are `/<vehicle_name>/<camera_frame_id>/<camera_type>` and `/<vehicle_name>/<camera_frame_id>/<camera_type>_labels` for labels topic.

For this I had to add `vehicle_name` to the `Vehicle` class. After finding a new free prim path for the vehicle, the last part of the vehicle's prim path (after last `/`) is used as a vehicle name (`quadrotor`). 

The `Quadrotor` class initializes the graphs right after initializing the sensors, so a new camera sensor can be added before creating a graph for it.

Added an example `8_camera_vehicle.py`, which uses the Iris Camera prim to create rgb and camera_info ROS2 Humble topics.