### PR TITLE
feat: lidar and ros2 lidar graph

### DIFF
--- a/docs/source/api/graphs.ros2_lidar.rst
+++ b/docs/source/api/graphs.ros2_lidar.rst
@@ -1,0 +1,7 @@
+ROS2 Lidar
+===========
+
+.. automodule:: pegasus.simulator.logic.graphs.ros2_lidar
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -12,6 +12,7 @@ Sensors
    sensors.gps
    sensors.imu
    sensors.magnetometer
+   sensors.lidar
 
 Graphs
 ------
@@ -21,6 +22,7 @@ Graphs
 
    graphs.graph
    graphs.ros2_camera
+   graphs.ros2_lidar
 
 Dynamics
 --------

--- a/docs/source/api/sensors.lidar.rst
+++ b/docs/source/api/sensors.lidar.rst
@@ -1,0 +1,7 @@
+Lidar
+======
+
+.. automodule:: pegasus.simulator.logic.sensors.lidar
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
@@ -4,3 +4,4 @@
 
 from .graph import Graph
 from .ros2_camera import ROS2Camera
+from .ros2_lidar import ROS2Lidar

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_lidar.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_lidar.py
@@ -1,0 +1,157 @@
+"""
+| File: ros2_lidar.py
+| License: BSD-3-Clause. Copyright (c) 2023, Micah Nye. All rights reserved.
+"""
+__all__ = ["ROS2Lidar"]
+
+import carb
+
+import omni.graph.core as og
+from omni.isaac.core.utils.prims import is_prim_path_valid
+
+from pegasus.simulator.logic.graphs import Graph
+from pegasus.simulator.logic.vehicles import Vehicle
+
+class ROS2Lidar(Graph):
+    """The class that implements the ROS2 Lidar graph. This class inherits the base class Graph.
+    """
+    def __init__(self, lidar_prim_path: str, config: dict = {}):
+        """Initialize the ROS2 Lidar class
+
+        Args:
+            lidar_prim_path (str): Path to the lidar prim. Global path when it starts with `/`, else local to vehicle prim path
+            config (dict): A Dictionary that contains all the parameters for configuring the ROS2Lidar - it can be empty or only have some of the parameters used by the ROS2Lidar.
+
+        Examples:
+            The dictionary default parameters are
+
+            >>> {"publish_scan": False,                     # publish scanner data as sensor_msgs/LaserScan (requires high_lod turned off)
+            >>>  "publish_point_cloud": True}               # publish scanner data as sensor_msgs/PointCloud2 (for 2D data, requires high_lod turned on)
+
+        Note:
+            To publish scan data, HighLOD needs to be turned off on the lidar prim. This means that only 2D laser scans are supported.
+        """
+
+        # Initialize the Super class "object" attribute
+        super().__init__(graph_type="ROS2Lidar")
+
+        # Save lidar path, frame id and ros topic name
+        self._lidar_prim_path = lidar_prim_path
+        self._frame_id = lidar_prim_path.rpartition("/")[-1] # frame_id of the lidar is the last prim path part after `/`
+        self._base_topic = ""
+
+        # Process the config dictionary
+        self._publish_scan = config.get("publish_scan", False)
+        self._publish_point_cloud = config.get("publish_point_cloud", True)
+
+    def initialize(self, vehicle: Vehicle):
+        """Method that initializes the graph of the lidar.
+
+        Args:
+            vehicle (Vehicle): The vehicle that this graph is attached to.
+        """
+
+        self._namespace = f"/{vehicle.vehicle_name}"
+        self._base_topic = f"/{self._frame_id}"
+
+        # Set the prim_path for the camera
+        if self._lidar_prim_path[0] != '/':
+            self._lidar_prim_path = f"{vehicle.prim_path}/{self._lidar_prim_path}"
+
+        # Check if the prim path is valid
+        if not is_prim_path_valid(self._lidar_prim_path):
+            carb.log_error(f"Cannot create ROS2 Lidar graph, the lidar prim path \"{self._lidar_prim_path}\" is not valid")
+            return
+        
+        # Set the prim paths for camera and tf graphs
+        graph_path = f"{self._lidar_prim_path}_pub"
+
+        # Graph configuration
+        graph_specs = {
+            "graph_path": graph_path,
+            "evaluator_name": "execution",
+        }
+
+        # Creating a default graph edit configuration
+        keys = og.Controller.Keys
+        graph_config = {
+            keys.CREATE_NODES: [
+                ("on_tick", "omni.graph.action.OnTick"),
+                ("isaac_read_simulation_time", "omni.isaac.core_nodes.IsaacReadSimulationTime"),
+            ],
+            keys.CONNECT: [],
+            keys.SET_VALUES: [],
+        }
+
+        # Add laser scan publishing to the graph
+        if self._publish_scan:
+
+            graph_config[keys.CREATE_NODES] += [
+                ("isaac_read_lidar_beams", "omni.isaac.range_sensor.IsaacReadLidarBeams"),
+                ("publish_laser_scan", "omni.isaac.ros2_bridge.ROS2PublishLaserScan")
+            ]
+            graph_config[keys.CONNECT] += [
+                ("on_tick.outputs:tick", "isaac_read_lidar_beams.inputs:execIn"),
+                ("isaac_read_lidar_beams.outputs:execOut", "publish_laser_scan.inputs:execIn"),
+                ("isaac_read_lidar_beams.outputs:azimuthRange", "publish_laser_scan.inputs:azimuthRange"),
+                ("isaac_read_lidar_beams.outputs:depthRange", "publish_laser_scan.inputs:depthRange"),
+                ("isaac_read_lidar_beams.outputs:horizontalFov", "publish_laser_scan.inputs:horizontalFov"),
+                ("isaac_read_lidar_beams.outputs:horizontalResolution", "publish_laser_scan.inputs:horizontalResolution"),
+                ("isaac_read_lidar_beams.outputs:intensitiesData", "publish_laser_scan.inputs:intensitiesData"),
+                ("isaac_read_lidar_beams.outputs:linearDepthData", "publish_laser_scan.inputs:linearDepthData"),
+                ("isaac_read_lidar_beams.outputs:numCols", "publish_laser_scan.inputs:numCols"),
+                ("isaac_read_lidar_beams.outputs:numRows", "publish_laser_scan.inputs:numRows"),
+                ("isaac_read_lidar_beams.outputs:rotationRate", "publish_laser_scan.inputs:rotationRate"),
+                ("isaac_read_simulation_time.outputs:simulationTime", "publish_laser_scan.inputs:timeStamp")
+            ]
+            graph_config[keys.SET_VALUES] += [
+                ("isaac_read_lidar_beams.inputs:lidarPrim", self._lidar_prim_path),
+                ("publish_laser_scan.inputs:frameId", self._frame_id),
+                ("publish_laser_scan.inputs:nodeNamespace", self._namespace),
+                ("publish_laser_scan.inputs:topicName", f"{self._base_topic}/scan")
+            ]
+
+        # Add point cloud publishing to the graph
+        if self._publish_point_cloud:
+            graph_config[keys.CREATE_NODES] += [
+                ("isaac_read_lidar_point_cloud", "omni.isaac.range_sensor.IsaacReadLidarPointCloud"),
+                ("publish_point_cloud", "omni.isaac.ros2_bridge.ROS2PublishPointCloud")
+            ]
+            graph_config[keys.CONNECT] += [
+                ("on_tick.outputs:tick", "isaac_read_lidar_point_cloud.inputs:execIn"),
+                ("isaac_read_lidar_point_cloud.outputs:execOut", "publish_point_cloud.inputs:execIn"),
+                ("isaac_read_lidar_point_cloud.outputs:data", "publish_point_cloud.inputs:data"),
+                ("isaac_read_simulation_time.outputs:simulationTime", "publish_point_cloud.inputs:timeStamp")
+            ]
+            graph_config[keys.SET_VALUES] += [
+                ("isaac_read_lidar_point_cloud.inputs:lidarPrim", self._lidar_prim_path),
+                ("publish_point_cloud.inputs:frameId", self._frame_id),
+                ("publish_point_cloud.inputs:nodeNamespace", self._namespace),
+                ("publish_point_cloud.inputs:topicName", f"{self._base_topic}/point_cloud")
+            ]
+        
+        # Create the lidar graph
+        (graph, _, _, _) = og.Controller.edit(
+            graph_specs,
+            graph_config
+        )
+        
+        # Run the ROS Lidar graph once to generate ROS publishers in SDGPipeline
+        og.Controller.evaluate_sync(graph)
+
+        # Also initialize the Super class with updated prim path (only lidar graph path)
+        super().initialize(graph_path)
+
+    def laser_scan_topic(self) -> str:
+        """
+        Returns:
+            (str) Lidar laser scan topic name if exists, else empty string
+        """
+        return f"{self._namespace}{self._base_topic}/scan" if self._publish_scan else ""
+
+    def point_cloud_topic(self) -> str:
+        """
+        Returns:
+            (str) Lidar point cloud topic name if exists, else empty string
+        """
+        return f"{self._namespace}{self._base_topic}/point_cloud" if self._publish_point_cloud else ""

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/__init__.py
@@ -8,3 +8,4 @@ from .barometer import Barometer
 from .gps import GPS
 from .imu import IMU
 from .magnetometer import Magnetometer
+from .lidar import Lidar

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/lidar.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/lidar.py
@@ -1,0 +1,149 @@
+"""
+| File: lidar.py
+| License: BSD-3-Clause. Copyright (c) 2023, Micah Nye. All rights reserved.
+| Description: Creates a lidar sensor
+"""
+__all__ = ["Lidar"]
+
+from omni.usd import get_context
+from omni.isaac.range_sensor._range_sensor import acquire_lidar_sensor_interface
+import omni.isaac.RangeSensorSchema as RangeSensorSchema
+from pxr import Sdf, Gf
+
+from pegasus.simulator.logic.state import State
+from pegasus.simulator.logic.sensors import Sensor
+from pegasus.simulator.logic.vehicles import Vehicle
+import numpy as np
+
+class Lidar(Sensor):
+    """The class that implements the Lidar sensor. This class inherits the base class Sensor.
+    """
+    def __init__(self, prim_path: str, config: dict = {}):
+        """Initialize the Lidar class
+        Args:
+            prim_path (str): Path to the lidar prim. Global path when it starts with `/`, else local to vehicle prim path
+            config (dict): A Dictionary that contains all the parameters for configuring the lidar - it can be empty or only have some of the parameters used by the lidar.
+        Examples:
+            The dictionary default parameters are
+            >>> {"position": [0.0, 0.0, 0.0],           # Meters
+            >>>  "yaw_offset": 0.0,                     # Degrees
+            >>>  "rotation_rate": 20.0,                 # Hz
+            >>>  "horizontal_fov": 360.0,               # Degrees
+            >>>  "horizontal_resolution": 1.0,          # Degrees
+            >>>  "vertical_fov": 10.0,                  # Degrees
+            >>>  "vertical_resolution": 1.0,            # Degrees
+            >>>  "min_range": 0.4,                      # Meters
+            >>>  "max_range": 100.0,                    # Meters
+            >>>  "high_lod": True,                      # High level of detail (True - draw all rays, False - draw horizontal rays)
+            >>>  "draw_points": False,                  # Draw lidar points where they hit an object
+            >>>  "draw_lines": False,                   # Draw lidar ray lines
+            >>>  "fill_state: False}                    # Fill state with sensor data
+        """
+
+        # Initialize the Super class "object" attribute
+        # update_rate not necessary
+        super().__init__(sensor_type="Lidar", update_rate=config.get("rotation_rate", 20.0))
+
+        # Save the id of the sensor
+        self._prim_path = prim_path
+        self._frame_id = prim_path.rpartition("/")[-1] # frame_id of the camera is the last prim path part after `/`
+
+        # The extension acquires the LIDAR interface at startup.  It will be released during extension shutdown.  We
+        # create a LIDAR prim using our schema, and then we interact with / query that prim using the python API found
+        # in lidar/bindings
+        self._li = acquire_lidar_sensor_interface()
+        self.lidar = None
+
+        # Get the lidar position relative to its parent prim
+        self._position = np.array(config.get("position", [0.0, 0.0, 0.0]))
+
+        # Get the lidar parameters
+        self._yaw_offset = config.get("yaw_offset", 0.0)
+        self._rotation_rate = config.get("rotation_rate", 20.0)
+        self._horizontal_fov = config.get("horizontal_fov", 360.0)
+        self._horizontal_resolution = config.get("horizontal_resolution", 1.0)
+        self._vertical_fov = config.get("vertical_fov", 10.0)
+        self._vertical_resolution = config.get("vertical_resolution", 1.0)
+        self._min_range = config.get("min_range", 0.4)
+        self._max_range = config.get("max_range", 100.0)
+        self._high_lod = config.get("high_lod", True)
+        self._draw_points = config.get("draw_points", False)
+        self._draw_lines = config.get("draw_lines", False)
+
+        # Save the current state of the range sensor
+        self._fill_state = config.get("fill_state", False)
+        if self._fill_state:
+            self._state = {
+                "frame_id": self._frame_id,
+                "depth": None,
+                "zenith": None,
+                "azimuth": None
+            }
+        else:
+            self._state = None
+
+    def initialize(self, vehicle: Vehicle):
+        """Method that initializes the lidar sensor. It also initalizes the sensor latitude, longitude and
+        altitude attributes as well as the vehicle that the sensor is attached to.
+        
+        Args:
+            vehicle (Vehicle): The vehicle that this sensor is attached to.
+        """
+
+        # Set the prim path for the camera
+        if self._prim_path[0] != '/':
+            self._prim_path = f"{vehicle.prim_path}/{self._prim_path}"
+        else:
+            self._prim_path = self._prim_path
+        
+
+        # create the LIDAR.  Before we can set any attributes on our LIDAR, we must first create the prim using our
+        # LIDAR schema, and then populate it with the parameters we will be manipulating.  If you try to manipulate
+        # a parameter before creating it, you will get a runtime error
+        stage = get_context().get_stage()
+        self.lidar = RangeSensorSchema.Lidar.Define(stage, Sdf.Path(self._prim_path))
+
+        # Set lidar parameters
+        self.lidar.AddTranslateOp().Set(Gf.Vec3f(*self._position))
+        self.lidar.CreateYawOffsetAttr().Set(self._yaw_offset)
+        self.lidar.CreateRotationRateAttr().Set(self._rotation_rate)
+        self.lidar.CreateHorizontalFovAttr().Set(self._horizontal_fov)
+        self.lidar.CreateHorizontalResolutionAttr().Set(self._horizontal_resolution)
+        self.lidar.CreateVerticalFovAttr().Set(self._vertical_fov)
+        self.lidar.CreateVerticalResolutionAttr().Set(self._vertical_resolution)
+        self.lidar.CreateMinRangeAttr().Set(self._min_range)
+        self.lidar.CreateMaxRangeAttr().Set(self._max_range)
+        self.lidar.CreateHighLodAttr().Set(self._high_lod)
+        self.lidar.CreateDrawPointsAttr().Set(self._draw_points)
+        self.lidar.CreateDrawLinesAttr().Set(self._draw_lines)
+    
+        # Set the sensor's frame path
+        self.frame_path = self._prim_path
+
+    @property
+    def state(self):
+        """
+        (dict) The 'state' of the sensor, i.e. the data produced by the sensor at any given point in time
+        """
+        return self._state
+    
+    @Sensor.update_at_rate
+    def update(self, state: State, dt: float):
+        """
+        Args:
+            state (State): The current state of the vehicle.
+            dt (float): The time elapsed between the previous and current function calls (s).
+        Returns:
+            (dict) A dictionary containing the current state of the sensor (the data produced by the sensor) or None
+        """
+
+        # Add the values to the dictionary and return it
+        if self._fill_state:
+            self._state = {
+                "frame_id": self._frame_id,
+                "depth": self._li.get_depth_data(self._prim_path),
+                "zenith": self._li.get_zenith_data(self._prim_path),
+                "azimuth": self._li.get_azimuth_data(self._prim_path),
+            }
+
+        return self._state

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
@@ -82,7 +82,11 @@ class Multirotor(Vehicle):
         # 2. Initialize all the vehicle sensors
         self._sensors = config.sensors
         for sensor in self._sensors:
-            sensor.initialize(PegasusInterface().latitude, PegasusInterface().longitude, PegasusInterface().altitude)
+            if sensor.sensor_type in ["Lidar"]:
+                sensor.initialize(self)
+            else:
+                sensor.initialize(PegasusInterface().latitude, PegasusInterface().longitude, PegasusInterface().altitude)
+            
 
         # Add callbacks to the physics engine to update each sensor at every timestep
         # and let the sensor decide depending on its internal update rate whether to generate new data

--- a/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
@@ -5,7 +5,7 @@
 
 # Graphs that can be used with the vehicles
 from pegasus.simulator.parser import Parser
-from pegasus.simulator.logic.graphs import ROS2Camera
+from pegasus.simulator.logic.graphs import ROS2Camera, ROS2Lidar
 
 
 class GraphParser(Parser):
@@ -13,8 +13,9 @@ class GraphParser(Parser):
 
         # Dictionary of available graphs to instantiate
         self.graphs = {
-            "ROS2 Camera": ROS2Camera
-        }
+            "ROS2 Camera": ROS2Camera,
+            "ROS2Lidar": ROS2Lidar
+                            }
 
     def parse(self, data_type: str, data_dict):
 

--- a/extensions/pegasus.simulator/pegasus/simulator/parser/sensor_parser.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/parser/sensor_parser.py
@@ -5,14 +5,20 @@
 
 # Sensors that can be used with the vehicles
 from pegasus.simulator.parser import Parser
-from pegasus.simulator.logic.sensors import Barometer, GPS, IMU, Magnetometer
+from pegasus.simulator.logic.sensors import Barometer, GPS, IMU, Magnetometer, Lidar
 
 
 class SensorParser(Parser):
     def __init__(self):
 
         # Dictionary of available sensors to instantiate
-        self.sensors = {"barometer": Barometer, "gps": GPS, "imu": IMU, "magnetometer": Magnetometer}
+        self.sensors = {
+            "barometer": Barometer,
+            "gps": GPS,
+            "imu": IMU,
+            "magnetometer": Magnetometer,
+            "lidar": Lidar
+            }
 
     def parse(self, data_type: str, data_dict):
 


### PR DESCRIPTION
Hi,

We created (with F1rrel) also new `Lidar` sensor `ROS2Lidar` OmniGraph.

`Lidar` creates new `Lidar` sensor class, which inherits base class `Sensor`.
- Input arguments for this class are `lidar_prim_path` and `config` parameters, such as `rotation_rate`, `horizontal_fov`, `horizontal_resolution`, `high_lod` etc. (full list can be seen in docs for `Lidar` sensor).
- Examples of usage can be seen below in zip file (more explained below in  `ROS2Lidar` OmniGraph)

This class consists of:
- Lidar sensor interface creation by `omni.isaac.range_sensor._range_sensor` using `acquire_lidar_sensor_interface` function.
- This class creates `Lidar` sensor instance under `lidar_prim_path` (recommended path for Quad-Copter usage is `body/lidar`). When `lidar_prim_path` is set and Prim is successfully created, Lidar is defined using `RangeSensorSchema.Lidar.Define` function, which can be found under `omni.isaac.RangeSensorSchema`. Then Lidar parameters are finally set using config.


 `ROS2Lidar` OmniGraph uses:
- `omni.isaac.range_sensor.IsaacReadLidarBeams` to get Lidar laser scan and publishes it to ROS2 as Lidar laser scan topic using `omni.isaac.ros2_bridge.ROS2PublishLaserScan`.
-  `omni.isaac.range_sensor.IsaacReadLidarPointCloud` to get Lidar point cloud and publishes it to ROS2 as Lidar point cloud topic using `omni.isaac.ros2_bridge.ROS2PublishPointCloud`.

Topics are being published under `/quadrotor/lidar/point_cloud` or `/quadrotor/lidar/scan` by default (depends on what type of Lidar you are using). Names of topics can be changed.

- Note: If you want to use Lidar laser scan function, `high_lod` has to be set on `False` in Lidar sensor config (is set to `True` by default, when no config parameter for `high_lod` is present)
 
To test implementation, please see included zip file of examples, where you can find:
- `9_ros2_graph_lidar_point_cloud.py` - example of vehicle using Lidar point cloud
- `9_ros2_graph_lidar_scan_360.py` - example of vehicle using 360° Lidar laser scan
- `9_ros2_graph_lidar_scan.py` - example of vehicle using 120° front Lidar scan

All examples can be viewed in Rviz2 to see if they are working properly. All you need is to add some shape (e.g. Cube) into ISAAC SIM and add `Rigid Body with Colliders Preset` in `Physics` tab.
- Note: Quad-copter is slightly tilted down when simulation is started, that's why Lidar scans ground in front of Quad-Copter, when it is sitting on the ground.

[9_ros2_graph_lidar_examples.zip](https://github.com/PegasusSimulator/PegasusSimulator/files/15095917/9_ros2_graph_lidar_examples.zip)
