### PR TITLE
feat: ros2 clock graph

### DIFF
--- a/docs/source/api/graphs.ros2_clock.rst
+++ b/docs/source/api/graphs.ros2_clock.rst
@@ -1,0 +1,7 @@
+ROS2 Clock
+===========
+
+.. automodule:: pegasus.simulator.logic.graphs.ros2_clock
+   :members:
+   :undoc-members:
+   :show-inheritance:

--- a/docs/source/api/index.rst
+++ b/docs/source/api/index.rst
@@ -21,6 +21,7 @@ Graphs
 
    graphs.graph
    graphs.ros2_camera
+   graphs.ros2_clock
 
 Dynamics
 --------

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/__init__.py
@@ -4,3 +4,4 @@
 
 from .graph import Graph
 from .ros2_camera import ROS2Camera
+from .ros2_clock import ROS2Clock

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_clock.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_clock.py
@@ -1,0 +1,78 @@
+"""
+| File: ros2_clock.py
+| License: BSD-3-Clause. Copyright (c) 2023, Micah Nye. All rights reserved.
+"""
+__all__ = ["ROS2Clock"]
+
+import carb
+
+import omni.graph.core as og
+from omni.isaac.core.utils.prims import is_prim_path_valid
+
+from pegasus.simulator.logic.graphs import Graph
+from pegasus.simulator.logic.vehicles import Vehicle
+
+
+class ROS2Clock(Graph):
+    """The class that implements the ROS2 Clock graph. This class inherits the base class Graph."""
+
+    def __init__(self, config: dict = {}):
+        """Initialize the ROS2 Clock class
+
+        Examples:
+            The dictionary default parameters are
+
+            >>> {"reset_on_stop": False}                # if true, the simulation time will reset when stop is pressed
+        """
+
+        # Initialize the Super class "object" attribute
+        super().__init__(graph_type="ROS2Clock")
+
+        # Process the config dictionary
+        self._reset_on_stop = config.get("reset_on_stop", False)
+
+    def initialize(self, vehicle: Vehicle):
+        """Method that initializes the graph.
+
+        Args:
+            vehicle (Vehicle): The vehicle that this graph is attached to.
+        """
+
+        # Create the graph under world with graph name clock and allow only one per world.
+        graph_path = "/World/clock_pub"
+        if is_prim_path_valid(graph_path):
+            carb.log_warn(f'{"ROS2 Clock Graph already exists"}')
+            return
+
+        # Graph configuration
+        graph_specs = {
+            "graph_path": graph_path,
+            "evaluator_name": "execution",
+        }
+
+        # Creating a graph edit configuration
+        keys = og.Controller.Keys
+        graph_config = {
+            keys.CREATE_NODES: [
+                ("on_tick", "omni.graph.action.OnPlaybackTick"),
+                ("simulation_time", "omni.isaac.core_nodes.IsaacReadSimulationTime"),
+                ("publish_clock", "omni.isaac.ros2_bridge.ROS2PublishClock"),
+            ],
+            keys.CONNECT: [
+                ("on_tick.outputs:tick", "publish_clock.inputs:execIn"),
+                ("simulation_time.outputs:simulationTime", "publish_clock.inputs:timeStamp"),
+            ],
+            keys.SET_VALUES: [
+                ("simulation_time.inputs:resetOnStop", self._reset_on_stop),
+                ("publish_clock.inputs:topicName", "/clock"),
+            ],
+        }
+
+        # Create the clock graph
+        (graph, _, _, _) = og.Controller.edit(graph_specs, graph_config)
+
+        # Run the clock graph once to generate ROS clock publisher in SDGPipeline
+        og.Controller.evaluate_sync(graph)
+
+        # Also initialize the Super class with updated prim path
+        super().initialize(graph_path)

--- a/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/parser/graphs_parser.py
@@ -5,16 +5,14 @@
 
 # Graphs that can be used with the vehicles
 from pegasus.simulator.parser import Parser
-from pegasus.simulator.logic.graphs import ROS2Camera
+from pegasus.simulator.logic.graphs import ROS2Camera, ROS2Clock
 
 
 class GraphParser(Parser):
     def __init__(self):
 
         # Dictionary of available graphs to instantiate
-        self.graphs = {
-            "ROS2 Camera": ROS2Camera
-        }
+        self.graphs = {"ROS2 Camera": ROS2Camera, "ROS2Clock": ROS2Clock}
 
     def parse(self, data_type: str, data_dict):
 


### PR DESCRIPTION
Hi,

I have added new `ROS2Clock` OmniGraph, which uses `omni.isaac.core_nodes.IsaacReadSimulationTime` to read simulation time, which is being published to ROS2 Topic using `omni.isaac.ros2_bridge.ROS2PublishClock`.
- Simulation time is being published to `/clock` topic by default.
- You can set using config, whether timer will reset itself when simulation is stopped using `reset_on_stop` parameter (is set to `False` if no config parameter is given)

Below you can find .zip file containing vehicle example for this graph. To test implementation just run vehicle example and check topics.

[9_graph_vehicle_clock_example.zip](https://github.com/PegasusSimulator/PegasusSimulator/files/15106390/9_graph_vehicle_clock_example.zip)
