### PR TITLE
fix: carb import before Simulation App is instantiated

### DIFF
--- a/examples/0_template_app.py
+++ b/examples/0_template_app.py
@@ -7,7 +7,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -18,6 +17,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core import World
 

--- a/examples/10_graphs.py
+++ b/examples/10_graphs.py
@@ -8,7 +8,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -19,6 +18,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/1_px4_single_vehicle.py
+++ b/examples/1_px4_single_vehicle.py
@@ -7,7 +7,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -18,6 +17,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/2_px4_multi_vehicle.py
+++ b/examples/2_px4_multi_vehicle.py
@@ -7,7 +7,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -18,6 +17,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/3_ros2_single_vehicle.py
+++ b/examples/3_ros2_single_vehicle.py
@@ -8,7 +8,6 @@ simulation with a single vehicle, controlled using the ROS2 backend system. NOTE
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -19,6 +18,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/4_python_single_vehicle.py
+++ b/examples/4_python_single_vehicle.py
@@ -8,7 +8,6 @@ for the vehicle from scratch and use it to perform a simulation, without using P
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -19,6 +18,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/5_python_multi_vehicle.py
+++ b/examples/5_python_multi_vehicle.py
@@ -8,7 +8,6 @@ for the vehicle from scratch and use it to perform a simulation, without using P
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -19,6 +18,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/6_paper_results.py
+++ b/examples/6_paper_results.py
@@ -10,7 +10,6 @@ otherwise, the path to the HDR environment is not recognized.
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -20,6 +19,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/8_camera_vehicle.py
+++ b/examples/8_camera_vehicle.py
@@ -8,7 +8,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -19,6 +18,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 

--- a/examples/9_people.py
+++ b/examples/9_people.py
@@ -7,7 +7,6 @@
 """
 
 # Imports to start Isaac Sim from this script
-import carb
 from isaacsim import SimulationApp
 
 # Start Isaac Sim's simulation environment
@@ -18,6 +17,7 @@ simulation_app = SimulationApp({"headless": False})
 # -----------------------------------
 # The actual script should start here
 # -----------------------------------
+import carb
 import omni.timeline
 from omni.isaac.core.world import World
 from omni.isaac.core.utils.extensions import disable_extension, enable_extension


### PR DESCRIPTION
`carb` should be imported after the SimulationApp app is instantiated.
```log
$ python3 PegasusSimulator/examples/1_px4_single_vehicle.py
access control disabled, clients can connect from any host
Traceback (most recent call last):
  File "//PegasusSimulator/examples/1_px4_single_vehicle.py", line 10, in <module>
    import carb
ModuleNotFoundError: No module named 'carb'
```