### PR TITLE
feat: Add Ardupilot multiagent functionality

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
@@ -290,8 +290,7 @@ class ArduPilotMavlinkBackend(Backend):
         # The connection will only be created once the simulation starts
         self._vehicle_id = config.vehicle_id
         self._connection = None
-        self._connection_port = f"{config.connection_type}:{config.connection_ip}:{config.connection_baseport}"
-        # TODO: config.vehicle_id)
+        self._connection_port = f"{config.connection_type}:{config.connection_ip}:{config.connection_baseport + self._vehicle_id * 10}"
 
         # Check if we need to autolaunch ArduPilot in the background or not
         self.ardupilot_autolaunch: bool = config.ardupilot_autolaunch
@@ -340,7 +339,7 @@ class ArduPilotMavlinkBackend(Backend):
 
         self.test_time = 0
 
-        self.ap = ArduPilotPlugin()
+        self.ap = ArduPilotPlugin(fdm_port_in=9002 + self._vehicle_id * 10)
         self.ap.drain_unread_packets()
 
     def update_sensor(self, sensor_type: str, data):

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/tools/ArduPilotPlugin.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/tools/ArduPilotPlugin.py
@@ -15,12 +15,12 @@ class ArduPilotPlugin:
     SERVO_PACKET_SIZE = 40
     SERVO_PACKET_MAGIC = 18458
     
-    def __init__(self):
+    def __init__(self, fdm_port_in=9002):
 
         # The address for the flight dynamics model (i.e. this plugin)
         self.fdm_address = '127.0.0.1'
         # The port for the flight dynamics model
-        self.fdm_port_in = 9002
+        self.fdm_port_in = fdm_port_in
 
         # FCU address and port are auto detected from receving UDP packet from connected client
         # The address for the SITL flight controller

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/tools/ardupilot_launch_tool.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/tools/ardupilot_launch_tool.py
@@ -62,14 +62,16 @@ class ArduPilotLaunchTool:
         """
         # sim_vehicle.py -v ArduCopter -f gazebo-iris --mode JSON --console --map
         command = [
-            "python3 " + self.ardupilot_dir + "/Tools/autotest/sim_vehicle.py",
+            "python3", f"{self.ardupilot_dir}/Tools/autotest/sim_vehicle.py",
             "-v", "ArduCopter",
             "-f", f"{self._get_vehicle_frame()}",
             "--model", f"{self.model}",
             f"{'--no-rebuild' if self._sitl_already_exists() else ''}",
             f"--console",
             f"--map",
-            # # f"-l 0,0,0,0"
+            "-I", f"{self.vehicle_id}",
+            "--sysid", f"{self.vehicle_id + 1}",
+            "--out", f"udp:127.0.0.1:{14550 + self.vehicle_id * 10}",
         ]
         command: str = " ".join(command)
         


### PR DESCRIPTION
Implements multiagent functionality for the Ardupilot backend by passing the instance and sysid to `sim_vehicle.py`. Also adds an multiagent python example similar to the one for the PX4 backend.

Example usage:
```bash
ISAACSIM_PYTHON examples/11_ardupilot_multi_vehicle.py
```
![Screenshot from 2025-02-15 16-10-02](https://github.com/user-attachments/assets/0d097089-4805-4b7e-840f-9506b742f24c)

Closes #65.
