### PR TITLE
fix: Ensure Ardupilot can be stopped and restarted as expected

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
@@ -339,9 +339,6 @@ class ArduPilotMavlinkBackend(Backend):
 
         self.test_time = 0
 
-        self.ap = ArduPilotPlugin(fdm_port_in=9002 + self._vehicle_id * 10)
-        self.ap.drain_unread_packets()
-
     def update_sensor(self, sensor_type: str, data):
         """Method that is used as callback for the vehicle for every iteration that a sensor produces new data. 
         Only the IMU, GPS, Barometer and  Magnetometer sensor data are stored to be sent through mavlink. Every other 
@@ -536,7 +533,7 @@ class ArduPilotMavlinkBackend(Backend):
 
     def start(self):
         """Method that handles the begining of the simulation of vehicle. It will try to open the mavlink connection 
-        interface and also attemp to launch ArduPilot in a background process if that option as specified in the config class
+        interface and also attempt to launch ArduPilot in a background process if that option as specified in the config class
         """
 
         # If we are already running the mavlink interface, then ignore the function call
@@ -571,6 +568,7 @@ class ArduPilotMavlinkBackend(Backend):
         # Close the mavlink connection
         self._connection.close()
         self._connection = None
+        self.ap = None
 
         # Close the ArduPilot if it was running
         if self.ardupilot_autolaunch and self.ardupilot_autolaunch is not None:
@@ -591,6 +589,9 @@ class ArduPilotMavlinkBackend(Backend):
 
         # Restart the sensor data
         self._sensor_data = SensorMsg()
+        
+        self.ap = ArduPilotPlugin(fdm_port_in=9002 + self._vehicle_id * 10)
+        self.ap.drain_unread_packets()
 
         # Restart the connection
         self._connection = mavutil.mavlink_connection(self._connection_port)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -239,7 +239,7 @@ class Vehicle(Robot):
 
             # Stop the graphical sensors
             for graphical_sensor in self._graphical_sensors:
-                graphical_sensor.stop
+                graphical_sensor.stop()
 
             # Signal all the backends that the simulation has stoped. This method is invoked automatically when the simulation stops
             for backend in self._backends:


### PR DESCRIPTION
## Description

When running PegasusSim with Ardupilot Backend pressing the Stop button closes the Ardupilot windows as expected but when trying to relaunch by pressing play the PegasusSim Backend doesn't connect to Ardupilot anymore.

```
Connected to ArduPilot controller @ 127.0.0.1:40883
Duplicate input frame
Socket timeout
Broken ArduPilot connection, resetting motor control.
```

![Screenshot from 2025-02-20 22-25-30](https://github.com/user-attachments/assets/1a2c74ef-b754-4534-b1d8-602b014c7a2e)

## Solution

I was able to solve this by reinitializing the `ArduPilotPlugin` on every start call.