### PR TITLE
fix: Ensure Ardupilot instances close when running IsaacSim is closed

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ardupilot_mavlink_backend.py
@@ -526,8 +526,7 @@ class ArduPilotMavlinkBackend(Backend):
 
         # When this object gets destroyed, close the mavlink connection to free the communication port
         try:
-            self._connection.close()
-            self._connection = None
+            self.stop()
         except:
             carb.log_info("Mavlink connection was not closed, because it was never opened")
 


### PR DESCRIPTION
Another small fix for running with Ardupilot. Sorry for missing it in #67.