### PR TITLE
fix: update examples's PX4 path

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -204,8 +204,6 @@
         "${workspaceFolder}/app/extscache/omni.kit.mesh.raycast-104.3.1+104.1.lx64.r.cp37",
         "${workspaceFolder}/app/extscache/omni.paint.brush.select-104.3.2+104.1",
         "${workspaceFolder}/app/extscache/omni.usd.schema.destruction-0.4.0+104.1.lx64.r.cp37",
-        "${workspaceFolder}/app/extscache/omni.timeline-1.0.10+10a4b5c0.lx64.r.cp310",
-        "${workspaceFolder}/app/extscache/omni.usd-1.12.2+10a4b5c0.lx64.r.cp310",
         "${workspaceFolder}/app/exts/omni.isaac.mjcf",
         "${workspaceFolder}/app/exts/omni.isaac.tests",
         "${workspaceFolder}/app/exts/omni.drivesim.sensors.nv.radar",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -204,6 +204,8 @@
         "${workspaceFolder}/app/extscache/omni.kit.mesh.raycast-104.3.1+104.1.lx64.r.cp37",
         "${workspaceFolder}/app/extscache/omni.paint.brush.select-104.3.2+104.1",
         "${workspaceFolder}/app/extscache/omni.usd.schema.destruction-0.4.0+104.1.lx64.r.cp37",
+        "${workspaceFolder}/app/extscache/omni.timeline-1.0.10+10a4b5c0.lx64.r.cp310",
+        "${workspaceFolder}/app/extscache/omni.usd-1.12.2+10a4b5c0.lx64.r.cp310",
         "${workspaceFolder}/app/exts/omni.isaac.mjcf",
         "${workspaceFolder}/app/exts/omni.isaac.tests",
         "${workspaceFolder}/app/exts/omni.drivesim.sensors.nv.radar",

--- a/examples/10_graphs.py
+++ b/examples/10_graphs.py
@@ -73,10 +73,14 @@ class PegasusApp:
         # Try to spawn the selected robot in the world to the specified namespace
         config_multirotor = MultirotorConfig()
         # Create the multirotor configuration
+        # Get PX4 directory from environment variable or use default path
+        import os
+        px4_dir = os.getenv("PX4_DIR", os.path.expanduser("~/PX4-Autopilot"))
+        
         mavlink_config = PX4MavlinkBackendConfig({
             "vehicle_id": 0,
             "px4_autolaunch": True,
-            "px4_dir": "/home/marcelo/PX4-Autopilot"
+            "px4_dir": px4_dir
         })
         config_multirotor.backends = [PX4MavlinkBackend(mavlink_config)]
 

--- a/examples/9_people.py
+++ b/examples/9_people.py
@@ -138,10 +138,14 @@ class PegasusApp:
         # Try to spawn the selected robot in the world to the specified namespace
         config_multirotor = MultirotorConfig()
         # # Create the multirotor configuration
+        # Get PX4 directory from environment variable or use default path
+        import os
+        px4_dir = os.getenv("PX4_DIR", os.path.expanduser("~/PX4-Autopilot"))
+
         mavlink_config = PX4MavlinkBackendConfig({
             "vehicle_id": 0,
             "px4_autolaunch": True,
-            "px4_dir": "/home/marcelo/PX4-Autopilot"
+            "px4_dir": px4_dir
         })
         config_multirotor.backends = [
             PX4MavlinkBackend(mavlink_config),


### PR DESCRIPTION
Makes the PX4 path more generic by allowing them to be set via environment variables, improving portability and flexibility for different environments.