### PR TITLE
TASK: Enable Isaac 5 0 Support

### DIFF
--- a/extensions/pegasus.simulator/config/extension.toml
+++ b/extensions/pegasus.simulator/config/extension.toml
@@ -39,7 +39,7 @@ icon = "data/icon.png"
 "omni.kit.uiapp" = {}
 "omni.isaac.core" = {}
 "omni.ui.scene" = {}
-"omni.kit.window.viewport" = {}
+"omni.kit.capture.viewport" = {}
 "isaacsim.replicator.agent.core" = {}
 
 # Main python module this extension provides, it will be publicly available as "import pegasus.simulator".

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/monocular_camera.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/monocular_camera.py
@@ -158,7 +158,7 @@ class MonocularCamera(GraphicalSensor):
             #if self._depth:
             #    self._state["depth"] = self._camera.get_depth()
 
-            if self._camera.get_projection_type() == "pinhole":
+            if self._camera.get_lens_distortion_model() == "pinhole":
                 self._state["intrinsics"] = self._camera.get_intrinsics_matrix()
             
         # If something goes wrong during the data acquisition, just return None

--- a/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
@@ -322,7 +322,7 @@ class UIDelegate:
             if camera_position is not None and camera_target is not None:
 
                 # Set the camera view to a fixed value
-                self._pegasus_sim.set_viewport_camera(eye=camera_position, target=camera_target)
+                self._pegasus_sim.set_viewport_camera(camera_position, camera_target)
     
     def on_set_new_default_px4_path(self):
         """


### PR DESCRIPTION
Dear all, 

it seems like we could easily extend support for isaac sim 5.0 by just a few minor changes. I will file this PR to make them visible. Following the question, is there a need to keep support for 4.5.0 and not moving towards 5.0 ? 

Happy hacking!