### PR TITLE
Ardupilot Fix 5.1.0: Update ardupilot's rendering_dt to 1/120

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/params.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/params.py
@@ -84,7 +84,7 @@ WORLD_SETTINGS = {
     'ardupilot': {
         "physics_dt": 1.0 / 800.0, # Reach communication of 250hz with ardupilot sitl
         "stage_units_in_meters": 1.0,
-        "rendering_dt": 1.0 / 100.0,
+        "rendering_dt": 1.0 / 120.0,
         "device": "cpu"
     },
     'ros2': {


### PR DESCRIPTION
Pegasus was throwing errors for ardupilot backend when running Ardupilot. The main issue was that the camera frequency was not divisible by the rendering frequency, which caused an exception in the Isaac Sim's camera module and prevented ArduPilot from running. Updating the rendering frequency so that it is divisible by the default camera rate (30 Hz) resolved the issue, and everything runs correctly now.

A user recently encountered this issue and posted a query about it on the ArduPilot Discord.