### PR TITLE
doc: fix Isaac Sim Python commands - missing $ for env vars

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Check the provided documentation [here](https://pegasussimulator.github.io/Pegas
 ⚠️ For users of versions prior to v5.1.0:
 A new command line tool named `isaac_run` is now used to launch Isaac Sim. **This is a function that should be added to your .bashrc or .zshrc file during the installation of Isaac Sim.** See [Installation Instructions](https://pegasussimulator.github.io/PegasusSimulator/source/setup/installation.html) for more details.
 
-This was done to simplify the launching of Isaac Sim from the terminal with ROS2 support. All previous instructions that mentioned launching Isaac Sim examples from the examples folder using the `ISAACSIM_PYTHON` command should now use `isaac_run` instead.
+This was done to simplify the launching of Isaac Sim from the terminal with ROS2 support. All previous instructions that mentioned launching Isaac Sim examples from the examples folder using the `$ISAACSIM_PYTHON` command should now use `isaac_run` instead.
 
 Please refer to the updated documentation for more details.
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -38,7 +38,7 @@ Latest Updates
 ⚠️ For users of versions prior to ``v5.1.0``:
 A new command line tool named ``isaac_run`` is now used to launch Isaac Sim. **This is a function that should be added to your .bashrc or .zshrc file during the installation of Isaac Sim.** See `Installation Instructions <https://pegasussimulator.github.io/PegasusSimulator/source/setup/installation.html>`__ for more details.
 
-This was done to simplify the launching of Isaac Sim from the terminal with ROS2 support. All previous instructions that mentioned launching Isaac Sim examples from the examples folder using the ``ISAACSIM_PYTHON`` command should now use ``isaac_run`` instead.
+This was done to simplify the launching of Isaac Sim from the terminal with ROS2 support. All previous instructions that mentioned launching Isaac Sim examples from the examples folder using the ``$ISAACSIM_PYTHON`` command should now use ``isaac_run`` instead.
 
 Please refer to the updated documentation for more details.
 

--- a/docs/source/setup/installation.rst
+++ b/docs/source/setup/installation.rst
@@ -185,10 +185,10 @@ open a new terminal window (**Ctrl+Alt+T**), and test the following commands:
     .. code:: bash
 
         # Run the bundled python interpreter and see if it prints on the terminal "Hello World."
-        ISAACSIM_PYTHON -c "print('Hello World.')"
+        $ISAACSIM_PYTHON -c "print('Hello World.')"
 
         # Run the python interpreter and check if we can run a script that starts the simulator and adds cubes to the world
-        ISAACSIM_PYTHON ${ISAACSIM_PATH}/standalone_examples/api/isaacsim.core.api/add_cubes.py
+        $ISAACSIM_PYTHON ${ISAACSIM_PATH}/standalone_examples/api/isaacsim.core.api/add_cubes.py
 
 If you were unable to run the commands above successfuly, then something is incorrectly configured. 
 Please do not proceed with this installation until you have everything setup correctly.
@@ -269,7 +269,7 @@ extension as a ``pip`` python module for the built-in ``ISAACSIM_PYTHON`` to rec
         cd extensions
 
         # Run the pip command using the built-in python interpreter
-        ISAACSIM_PYTHON -m pip install --editable pegasus.simulator
+        $ISAACSIM_PYTHON -m pip install --editable pegasus.simulator
 
 We use the ``--editable`` flag so that the content of the extension is linked instead of copied. After this step, you 
 should be able to run the python standalone examples inside the ``examples`` folder.


### PR DESCRIPTION
Fixed missing `$` in front of ISAACSIM_PYTHON commands in installation.rst