### PR TITLE
Dev cuda

### DIFF
--- a/examples/4_python_single_vehicle.py
+++ b/examples/4_python_single_vehicle.py
@@ -60,7 +60,7 @@ class PegasusApp:
         #self.pg._world = World(**self.pg._world_settings)
 
         world_settings = dict(self.pg._world_settings) 
-        world_settings["device"] = "cuda"           
+        world_settings["device"] = "cpu"           
 
         self.pg._world = World(**world_settings)
 

--- a/examples/4_python_single_vehicle.py
+++ b/examples/4_python_single_vehicle.py
@@ -57,7 +57,13 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
+        #self.pg._world = World(**self.pg._world_settings)
+
+        world_settings = dict(self.pg._world_settings) 
+        world_settings["device"] = "cuda"           
+
+        self.pg._world = World(**world_settings)
+
         self.world = self.pg.world
 
         # Launch one of the worlds provided by NVIDIA

--- a/examples/test_iris_rigid_prim.py
+++ b/examples/test_iris_rigid_prim.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""
+| File: 4_python_single_vehicle.py
+| Author: Marcelo Jacinto and Joao Pinto (marcelo.jacinto@tecnico.ulisboa.pt, joao.s.pinto@tecnico.ulisboa.pt)
+| License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto. All rights reserved.
+| Description: This files serves as an example on how to use the control backends API to create a custom controller 
+for the vehicle from scratch and use it to perform a simulation, without using PX4 nor ROS.
+"""
+
+# Imports to start Isaac Sim from this script
+import carb
+from isaacsim import SimulationApp
+
+# Start Isaac Sim's simulation environment
+# Note: this simulation app must be instantiated right after the SimulationApp import, otherwise the simulator will crash
+# as this is the object that will load all the extensions and load the actual simulator.
+simulation_app = SimulationApp({"headless": True})
+
+# -----------------------------------
+# The actual script should start here
+# -----------------------------------
+import omni.timeline
+from omni.isaac.core.world import World
+
+# Import the Pegasus API for simulating drones
+from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
+from pegasus.simulator.logic.interface.pegasus_interface import PegasusInterface
+
+import numpy as np
+import torch
+from pxr import UsdGeom, Gf, UsdLux, PhysxSchema
+
+import isaacsim.core.utils.stage as stage_utils
+#from isaacsim.core.prims import Articulation
+from isaacsim.core.prims import RigidPrim
+
+USD_PATH = "/home/rodrigogomes/PegasusSimulator/extensions/pegasus.simulator/pegasus/simulator/assets/Robots/Iris/iris.usd"
+
+class PegasusApp:
+    """
+            forces = torch.zeros((self.n_envs, self.num_children, 3), device=self.device, dtype=torch.float32)
+            forces[:, 1:, 2] = float(0.005) 
+            forces = forces.reshape((self.prims.count, 3))
+
+            torques = torch.zeros((self.n_envs, self.num_children, 3), device=self.device, dtype=torch.float32)
+            torques[:, 0, 2] = float(0.01) 
+            torques = torques.reshape((self.prims.count, 3))
+
+            #print("Applying forces:", forces)
+            #print("Applying torques:", torques)
+
+            self.prims.apply_forces_and_torques_at_pos(forces, torques, is_global=False)
+
+            # Update the UI of the app and perform the physics step
+            self.pg._world.step(render=True)
+
+            i += 1
+            print("Step:", i)
+    A Template class that serves as an example on how to build a simple Isaac Sim standalone App.
+    """
+
+    def __init__(self, n_envs=8, spacing=3.0):
+        """
+        Method that initializes the PegasusApp and is used to setup the simulation environment.
+        """
+
+        # Acquire the timeline that will be used to start/stop the simulation
+        self.timeline = omni.timeline.get_timeline_interface()
+
+        # Start the Pegasus Interface
+        self.pg = PegasusInterface()
+
+        # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
+        # spawning asset primitives, etc.
+        #self.pg._world = World(**self.pg._world_settings)
+        self.pg._world = World(
+            physics_dt = 1.0 / 100.0,
+            stage_units_in_meters=1.0,
+            rendering_dt=1.0 / 60.0,
+            device="cuda"
+        )
+
+        stage = stage_utils.get_current_stage()
+        scenePrim = stage.GetPrimAtPath("/physicsScene")  # adjust to your scene path
+        print(scenePrim)
+        physxSceneAPI = PhysxSchema.PhysxSceneAPI.Apply(scenePrim)
+        physxSceneAPI.CreateGpuFoundLostAggregatePairsCapacityAttr().Set(24576)        
+
+        self.pg._world.get_physics_context().enable_gpu_dynamics(True)
+        print(self.pg._world.get_physics_context().is_gpu_dynamics_enabled())
+
+        
+        #UsdGeom.Xform.Define(stage, "/World")
+
+        # Launch one of the worlds provided by NVIDIA
+        self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
+
+        self.n_envs = n_envs
+
+        # Spawn N IRIS
+        side = int(np.ceil(np.sqrt(self.n_envs)))
+        for i in range(self.n_envs):
+            prim_path = f"/World/quadrotor{i}"
+            stage_utils.add_reference_to_stage(USD_PATH, prim_path=prim_path)
+
+            x = (i % side) * spacing
+            y = (i // side) * spacing
+            z = 0.30
+
+            prim = stage.GetPrimAtPath(prim_path)
+            xformable = UsdGeom.XformCommonAPI(UsdGeom.Xformable(prim))
+            xformable.SetTranslate(Gf.Vec3d(float(x), float(y), float(z)))
+            rotate_op = prim.GetAttribute("xformOp:rotateXYZ")
+            rotate_op.Set(Gf.Vec3d(45.0, 0.0, 0.0))
+
+            self.num_children = len(prim.GetChildren())
+
+        self.pg._world.get_physics_context().set_gravity(0.0)
+        self.pg._world.reset()
+
+        # Bodies (for mass estimate)
+        self.prims = RigidPrim(prim_paths_expr="/World/quadrotor.*/.*", name="prims")
+        self.prims.initialize()
+
+        print("prims.count =", self.prims.count)
+
+        #print("prims.prim_paths =", self.prims.prim_paths)
+
+        self.device = torch.device("cuda")
+
+
+    def run(self):
+        """
+        Method that implements the application main loop, where the physics steps are executed.
+        """
+
+        # Start the simulation
+        self.timeline.play()
+
+        i = 0
+        # The "infinite" loop
+        while simulation_app.is_running():
+
+            # One force vector per rotor rigid body => shape (N*4, 3)
+            forces = torch.zeros((self.n_envs, self.num_children, 3), device=self.device, dtype=torch.float32)
+            forces[:, 1:, 2] = float(0.005) 
+            forces = forces.reshape((self.prims.count, 3))
+
+            torques = torch.zeros((self.n_envs, self.num_children, 3), device=self.device, dtype=torch.float32)
+            torques[:, 0, 2] = float(0.01) 
+            torques = torques.reshape((self.prims.count, 3))
+
+            #print("Applying forces:", forces)
+            #print("Applying torques:", torques)
+
+            self.prims.apply_forces_and_torques_at_pos(forces, torques, is_global=False)
+
+            # Update the UI of the app and perform the physics step
+            self.pg._world.step(render=False, step_sim=True)
+
+            i += 1
+            print("Step:", i)
+        
+        # Cleanup and stop
+        carb.log_warn("PegasusApp Simulation App is closing.")
+        self.timeline.stop()
+        simulation_app.close()
+
+def main():
+
+    # Instantiate the template app
+    pg_app = PegasusApp(n_envs=4096, spacing=3.0)
+
+    # Run the application loop
+    pg_app.run()
+
+if __name__ == "__main__":
+    main()

--- a/examples/utils/nonlinear_controller.py
+++ b/examples/utils/nonlinear_controller.py
@@ -142,7 +142,7 @@ class NonlinearController(Backend):
         statistics["ep"] = torch.stack(self.position_error_over_time)
         statistics["ev"] = torch.stack(self.velocity_error_over_time)
         statistics["er"] = torch.stack(self.atittude_error_over_time)
-        statistics["ew"] = torch.tensor(self.attitude_rate_error_over_time, dtype=torch.float32, device=self.device)
+        statistics["ew"] = torch.stack(self.attitude_rate_error_over_time)
         torch.save(statistics, self.results_files)
         carb.log_warn("Statistics saved to: " + self.results_files)
 
@@ -250,11 +250,11 @@ class NonlinearController(Backend):
         X_c_des = torch.stack([torch.cos(yaw_ref), torch.sin(yaw_ref), torch.tensor(0.0, dtype=torch.float32, device=self.device)])
 
         # Compute Y_b_des
-        Z_b_cross_X_c = torch.cross(Z_b_des, X_c_des)
+        Z_b_cross_X_c = torch.cross(Z_b_des, X_c_des, dim=0)
         Y_b_des = Z_b_cross_X_c / torch.linalg.norm(Z_b_cross_X_c)
 
         # Compute X_b_des
-        X_b_des = torch.cross(Y_b_des, Z_b_des)
+        X_b_des = torch.cross(Y_b_des, Z_b_des, dim=0)
 
         # Compute the desired rotation R_des = [X_b_des | Y_b_des | Z_b_des]
         R_des = torch.stack([X_b_des, Y_b_des, Z_b_des], dim=1)

--- a/examples/utils/nonlinear_controller.py
+++ b/examples/utils/nonlinear_controller.py
@@ -19,7 +19,11 @@ from pegasus.simulator.logic.backends import Backend
 
 # Auxiliary scipy and numpy modules
 import numpy as np
-from scipy.spatial.transform import Rotation
+import torch
+
+#from scipy.spatial.transform import Rotation
+import pytorch3d.transforms as transforms
+
 
 class NonlinearController(Backend):
     """A nonlinear controller class. It implements a nonlinear controller that allows a vehicle to track
@@ -41,26 +45,30 @@ class NonlinearController(Backend):
         Kd=[8.5, 8.5, 8.5],
         Ki=[1.50, 1.50, 1.50],
         Kr=[3.5, 3.5, 3.5],
-        Kw=[0.5, 0.5, 0.5]):
+        Kw=[0.5, 0.5, 0.5],
+        device = "cpu"):
+
+        # Set device
+        self.device = device
 
         # The current rotor references [rad/s]
-        self.input_ref = [0.0, 0.0, 0.0, 0.0]
+        self.input_ref = torch.zeros((4,), dtype=torch.float32, device=device)
 
         # The current state of the vehicle expressed in the inertial frame (in ENU)
-        self.p = np.zeros((3,))                   # The vehicle position
-        self.R: Rotation = Rotation.identity()    # The vehicle attitude
-        self.w = np.zeros((3,))                   # The angular velocity of the vehicle
-        self.v = np.zeros((3,))                   # The linear velocity of the vehicle in the inertial frame
-        self.a = np.zeros((3,))                   # The linear acceleration of the vehicle in the inertial frame
+        self.p = torch.zeros((3,), dtype=torch.float32, device=device)                   # The vehicle position
+        self.R: transforms.Rotation = transforms.quaternion_to_matrix(torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=device))    # The vehicle attitude
+        self.w = torch.zeros((3,), dtype=torch.float32, device=device)                   # The angular velocity of the vehicle
+        self.v = torch.zeros((3,), dtype=torch.float32, device=device)                   # The linear velocity of the vehicle in the inertial frame
+        self.a = torch.zeros((3,), dtype=torch.float32, device=device)                   # The linear acceleration of the vehicle in the inertial frame
 
         # Define the control gains matrix for the outer-loop
-        self.Kp = np.diag(Kp)
-        self.Kd = np.diag(Kd)
-        self.Ki = np.diag(Ki)
-        self.Kr = np.diag(Kr)
-        self.Kw = np.diag(Kw)
+        self.Kp = torch.diag(torch.tensor(Kp, dtype=torch.float32, device=device))
+        self.Kd = torch.diag(torch.tensor(Kd, dtype=torch.float32, device=device))
+        self.Ki = torch.diag(torch.tensor(Ki, dtype=torch.float32, device=device))
+        self.Kr = torch.diag(torch.tensor(Kr, dtype=torch.float32, device=device))
+        self.Kw = torch.diag(torch.tensor(Kw, dtype=torch.float32, device=device))
 
-        self.int = np.array([0.0, 0.0, 0.0])
+        self.int = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=device)
 
         # Define the dynamic parameters for the vehicle
         self.m = 1.50        # Mass in Kg
@@ -128,14 +136,14 @@ class NonlinearController(Backend):
             return
         
         statistics = {}
-        statistics["time"] = np.array(self.time_vector)
-        statistics["p"] = np.vstack(self.position_over_time)
-        statistics["desired_p"] = np.vstack(self.desired_position_over_time)
-        statistics["ep"] = np.vstack(self.position_error_over_time)
-        statistics["ev"] = np.vstack(self.velocity_error_over_time)
-        statistics["er"] = np.vstack(self.atittude_error_over_time)
-        statistics["ew"] = np.vstack(self.attitude_rate_error_over_time)
-        np.savez(self.results_files, **statistics)
+        statistics["time"] = torch.tensor(self.time_vector, dtype=torch.float32, device=self.device)
+        statistics["p"] = torch.stack(self.position_over_time)
+        statistics["desired_p"] = torch.stack(self.desired_position_over_time)
+        statistics["ep"] = torch.stack(self.position_error_over_time)
+        statistics["ev"] = torch.stack(self.velocity_error_over_time)
+        statistics["er"] = torch.stack(self.atittude_error_over_time)
+        statistics["ew"] = torch.tensor(self.attitude_rate_error_over_time, dtype=torch.float32, device=self.device)
+        torch.save(statistics, self.results_files)
         carb.log_warn("Statistics saved to: " + self.results_files)
 
         self.reset_statistics()
@@ -159,7 +167,7 @@ class NonlinearController(Backend):
             state (State): The current state of the vehicle.
         """
         self.p = state.position
-        self.R = Rotation.from_quat(state.attitude)
+        self.R = transforms.quaternion_to_matrix(state.attitude)
         self.w = state.angular_velocity
         self.v = state.linear_velocity
 
@@ -198,10 +206,10 @@ class NonlinearController(Backend):
         # Update using an external trajectory
         if self.trajectory is not None:
             # the target positions [m], velocity [m/s], accelerations [m/s^2], jerk [m/s^3], yaw-angle [rad], yaw-rate [rad/s]
-            p_ref = np.array([self.trajectory[self.index, 1], self.trajectory[self.index, 2], self.trajectory[self.index, 3]])
-            v_ref = np.array([self.trajectory[self.index, 4], self.trajectory[self.index, 5], self.trajectory[self.index, 6]])
-            a_ref = np.array([self.trajectory[self.index, 7], self.trajectory[self.index, 8], self.trajectory[self.index, 9]])
-            j_ref = np.array([self.trajectory[self.index, 10], self.trajectory[self.index, 11], self.trajectory[self.index, 12]])
+            p_ref = torch.tensor([self.trajectory[self.index, 1], self.trajectory[self.index, 2], self.trajectory[self.index, 3]], dtype=torch.float32, device=self.device)
+            v_ref = torch.tensor([self.trajectory[self.index, 4], self.trajectory[self.index, 5], self.trajectory[self.index, 6]], dtype=torch.float32, device=self.device)
+            a_ref = torch.tensor([self.trajectory[self.index, 7], self.trajectory[self.index, 8], self.trajectory[self.index, 9]], dtype=torch.float32, device=self.device)
+            j_ref = torch.tensor([self.trajectory[self.index, 10], self.trajectory[self.index, 11], self.trajectory[self.index, 12]], dtype=torch.float32, device=self.device)
             yaw_ref = self.trajectory[self.index, 13]
             yaw_rate_ref = self.trajectory[self.index, 14]
         # Or update the reference using the built-in trajectory
@@ -225,46 +233,45 @@ class NonlinearController(Backend):
         ei = self.int
 
         # Compute F_des term
-        F_des = -(self.Kp @ ep) - (self.Kd @ ev) - (self.Ki @ ei) + np.array([0.0, 0.0, self.m * self.g]) + (self.m * a_ref)
+        F_des = -(self.Kp @ ep) - (self.Kd @ ev) - (self.Ki @ ei) + torch.tensor([0.0, 0.0, self.m * self.g], dtype=torch.float32, device=self.device) + (self.m * a_ref)
 
         # Get the current axis Z_B (given by the last column of the rotation matrix)
-        Z_B = self.R.as_matrix()[:,2]
+        Z_B = self.R[:,2]
 
         # Get the desired total thrust in Z_B direction (u_1)
         u_1 = F_des @ Z_B
 
         # Compute the desired body-frame axis Z_b
-        Z_b_des = F_des / np.linalg.norm(F_des)
+        Z_b_des = F_des / torch.linalg.norm(F_des)
+
+        yaw_ref = torch.as_tensor(yaw_ref, dtype=torch.float32, device=self.device)
 
         # Compute X_C_des 
-        X_c_des = np.array([np.cos(yaw_ref), np.sin(yaw_ref), 0.0])
+        X_c_des = torch.stack([torch.cos(yaw_ref), torch.sin(yaw_ref), torch.tensor(0.0, dtype=torch.float32, device=self.device)])
 
         # Compute Y_b_des
-        Z_b_cross_X_c = np.cross(Z_b_des, X_c_des)
-        Y_b_des = Z_b_cross_X_c / np.linalg.norm(Z_b_cross_X_c)
+        Z_b_cross_X_c = torch.cross(Z_b_des, X_c_des)
+        Y_b_des = Z_b_cross_X_c / torch.linalg.norm(Z_b_cross_X_c)
 
         # Compute X_b_des
-        X_b_des = np.cross(Y_b_des, Z_b_des)
+        X_b_des = torch.cross(Y_b_des, Z_b_des)
 
         # Compute the desired rotation R_des = [X_b_des | Y_b_des | Z_b_des]
-        R_des = np.c_[X_b_des, Y_b_des, Z_b_des]
-        R = self.R.as_matrix()
+        R_des = torch.stack([X_b_des, Y_b_des, Z_b_des], dim=1)
 
         # Compute the rotation error
-        e_R = 0.5 * self.vee((R_des.T @ R) - (R.T @ R_des))
+        e_R = 0.5 * self.vee((R_des.T @ self.R) - (self.R.T @ R_des))
 
         # Compute an approximation of the current vehicle acceleration in the inertial frame (since we cannot measure it directly)
-        self.a = (u_1 * Z_B) / self.m - np.array([0.0, 0.0, self.g])
+        self.a = (u_1 * Z_B) / self.m - torch.tensor([0.0, 0.0, self.g], dtype=torch.float32, device=self.device)
 
         # Compute the desired angular velocity by projecting the angular velocity in the Xb-Yb plane
         # projection of angular velocity on xB − yB plane
         # see eqn (7) from [2].
-        hw = (self.m / u_1) * (j_ref - np.dot(Z_b_des, j_ref) * Z_b_des) 
+        hw = (self.m / u_1) * (j_ref - torch.dot(Z_b_des, j_ref) * Z_b_des) 
         
         # desired angular velocity
-        w_des = np.array([-np.dot(hw, Y_b_des), 
-                           np.dot(hw, X_b_des), 
-                           yaw_rate_ref * Z_b_des[2]])
+        w_des = torch.stack([-torch.dot(hw, Y_b_des), torch.dot(hw, X_b_des), yaw_rate_ref * Z_b_des[2]])
 
         # Compute the angular velocity error
         e_w = self.w - w_des
@@ -293,9 +300,9 @@ class NonlinearController(Backend):
         """Auxiliary function that computes the 'v' map which takes elements from so(3) to R^3.
 
         Args:
-            S (np.array): A matrix in so(3)
+            S (torch.tensor): A matrix in so(3)
         """
-        return np.array([-S[1,2], S[0,2], -S[0,1]])
+        return torch.tensor([-S[1,2], S[0,2], -S[0,1]], dtype=torch.float32, device=S.device)
     
     def reset_statistics(self):
 
@@ -331,17 +338,19 @@ class NonlinearController(Backend):
             reverse (bool, optional): Choose whether we want to flip the curve (so that we can have 2 drones almost touching). Defaults to False.
 
         Returns:
-            np.ndarray: A 3x1 array with the x, y ,z desired [m]
+            torch.tensor: A 3x1 tensor with the x, y ,z desired [m]
         """
+        t = torch.as_tensor(t, dtype=torch.float32, device=self.device)
+        s = torch.as_tensor(s, dtype=torch.float32, device=self.device)
 
         x = t
-        z = 1 / s * np.exp(-0.5 * np.power(t/s, 2)) + 1.0
-        y = 1 / s * np.exp(-0.5 * np.power(t/s, 2))
+        z = 1 / s * torch.exp(-0.5 * torch.power(t/s, 2)) + 1.0
+        y = 1 / s * torch.exp(-0.5 * torch.power(t/s, 2))
 
         if reverse == True:
-            y = -1 / s * np.exp(-0.5 * np.power(t/s, 2)) + 4.5
+            y = -1 / s * torch.exp(-0.5 * torch.power(t/s, 2)) + 4.5
 
-        return np.array([x,y,z])
+        return torch.tensor([x,y,z], dtype=torch.float32, device=self.device)
 
     def d_pd(self, t, s, reverse=False):
         """The desired velocity of the built-in trajectory
@@ -352,17 +361,19 @@ class NonlinearController(Backend):
             reverse (bool, optional): Choose whether we want to flip the curve (so that we can have 2 drones almost touching). Defaults to False.
 
         Returns:
-            np.ndarray: A 3x1 array with the d_x, d_y ,d_z desired [m/s]
+            torch.tensor: A 3x1 tensor with the d_x, d_y ,d_z desired [m/s]
         """
+        t = torch.as_tensor(t, dtype=torch.float32, device=self.device)
+        s = torch.as_tensor(s, dtype=torch.float32, device=self.device)
 
         x = 1.0
-        y = -(t * np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,3)
-        z = -(t * np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,3)
+        y = -(t * torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,3)
+        z = -(t * torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,3)
 
         if reverse == True:
-            y = (t * np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,3)
+            y = (t * torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,3)
 
-        return np.array([x,y,z])
+        return torch.tensor([x,y,z], dtype=torch.float32, device=self.device)
 
     def dd_pd(self, t, s, reverse=False):
         """The desired acceleration of the built-in trajectory
@@ -375,15 +386,17 @@ class NonlinearController(Backend):
         Returns:
             np.ndarray: A 3x1 array with the dd_x, dd_y ,dd_z desired [m/s^2]
         """
+        t = torch.as_tensor(t, dtype=torch.float32, device=self.device)
+        s = torch.as_tensor(s, dtype=torch.float32, device=self.device)
 
         x = 0.0
-        y = (np.power(t,2)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5) - np.exp(-np.power(t,2)/(2*np.power(s,2)))/np.power(s,3)
-        z = (np.power(t,2)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5) - np.exp(-np.power(t,2)/(2*np.power(s,2)))/np.power(s,3)
+        y = (torch.power(t,2)*torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,5) - torch.exp(-torch.power(t,2)/(2*torch.power(s,2)))/torch.power(s,3)
+        z = (torch.power(t,2)*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,5) - torch.exp(-torchpower(t,2)/(2*torchpower(s,2)))/torchpower(s,3)
 
         if reverse == True:
-            y = np.exp(-np.power(t,2)/(2*np.power(s,2)))/np.power(s,3) - (np.power(t,2)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5)
+            y = torch.exp(-torchpower(t,2)/(2*torchpower(s,2)))/torchpower(s,3) - (torchpower(t,2)*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,5)
 
-        return np.array([x,y,z])
+        return torch.tensor([x,y,z], dtype=torch.float32, device=self.device)
 
     def ddd_pd(self, t, s, reverse=False):
         """The desired jerk of the built-in trajectory
@@ -394,16 +407,19 @@ class NonlinearController(Backend):
             reverse (bool, optional): Choose whether we want to flip the curve (so that we can have 2 drones almost touching). Defaults to False.
 
         Returns:
-            np.ndarray: A 3x1 array with the ddd_x, ddd_y ,ddd_z desired [m/s^3]
+            torch.tensor: A 3x1 tensor with the ddd_x, ddd_y ,ddd_z desired [m/s^3]
         """
+        t = torch.as_tensor(t, dtype=torch.float32, device=self.device)
+        s = torch.as_tensor(s, dtype=torch.float32, device=self.device)
+
         x = 0.0
-        y = (3*t*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5) - (np.power(t,3)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,7)
-        z = (3*t*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5) - (np.power(t,3)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,7)
+        y = (3*t*torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,5) - (torch.power(t,3)*torch.exp(-torch.power(t,2)/(2*torch.power(s,2))))/torch.power(s,7)
+        z = (3*t*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,5) - (torchpower(t,3)*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,7)
 
         if reverse == True:
-            y = (np.power(t,3)*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,7) - (3*t*np.exp(-np.power(t,2)/(2*np.power(s,2))))/np.power(s,5)
+            y = (torch.power(t,3)*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,7) - (3*t*torch.exp(-torchpower(t,2)/(2*torchpower(s,2))))/torchpower(s,5)
 
-        return np.array([x,y,z])
+        return torch.tensor([x,y,z], dtype=torch.float32, device=self.device)
 
     def yaw_d(self, t, s):
         """The desired yaw of the built-in trajectory
@@ -414,9 +430,9 @@ class NonlinearController(Backend):
             reverse (bool, optional): Choose whether we want to flip the curve (so that we can have 2 drones almost touching). Defaults to False.
 
         Returns:
-            np.ndarray: A float with the desired yaw in rad
+            torch.tensor: A float with the desired yaw in rad
         """
-        return 0.0
+        return torch.tensor(0.0, dtype=torch.float32, device=self.device)
     
     def d_yaw_d(self, t, s):
         """The desired yaw_rate of the built-in trajectory
@@ -427,10 +443,10 @@ class NonlinearController(Backend):
             reverse (bool, optional): Choose whether we want to flip the curve (so that we can have 2 drones almost touching). Defaults to False.
 
         Returns:
-            np.ndarray: A float with the desired yaw_rate in rad/s
+            torch.tensor: A float with the desired yaw_rate in rad/s
         """
-        return 0.0
-    
+        return torch.tensor(0.0, dtype=torch.float32, device=self.device)
+
     def reset(self):
         """
         Method that when implemented, should handle the reset of the vehicle simulation to its original state

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/rotations.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/rotations.py
@@ -4,25 +4,32 @@
 | License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto. All rights reserved.
 | Description: Implements utilitary rotations between ENU and NED inertial frame conventions and FLU and FRD body frame conventions.
 """
-import numpy as np
-from scipy.spatial.transform import Rotation
+#import numpy as np
+import torch
+
+import pytorch3d.transforms as transforms
 
 # Quaternion for rotation between ENU and NED INERTIAL frames
 # NED to ENU: +PI/2 rotation about Z (Down) followed by a +PI rotation around X (old North/new East)
 # ENU to NED: +PI/2 rotation about Z (Up) followed by a +PI rotation about X (old East/new North)
 # This rotation is symmetric, so q_ENU_to_NED == q_NED_to_ENU.
-# Note: this quaternion follows the convention [qx, qy, qz, qw]
-q_ENU_to_NED = np.array([0.70711, 0.70711, 0.0, 0.0])
+# Note: this quaternion follows the convention [qw, qx, qy, qz]
+# q_ENU_to_NED -> [0.0, 0.70711, 0.70711, 0.0]
 
-# A scipy rotation from the ENU inertial frame to the NED inertial frame of reference
-rot_ENU_to_NED = Rotation.from_quat(q_ENU_to_NED)
+# Rotation from the ENU inertial frame to the NED inertial frame of reference
+def rot_ENU_to_NED(device, dtype):
+    q_ENU_to_NED = torch.tensor([0.0, 0.70711, 0.70711, 0.0], dtype=torch.float32, device=device)
+    return transforms.quaternion_to_matrix(q_ENU_to_NED)
 
 # Quaternion for rotation between body FLU and body FRD frames
 # +PI rotation around X (Forward) axis rotates from Forward, Right, Down (aircraft)
 # to Forward, Left, Up (base_link) frames and vice-versa.
 # This rotation is symmetric, so q_FLU_to_FRD == q_FRD_to_FLU.
-# Note: this quaternion follows the convention [qx, qy, qz, qw]
-q_FLU_to_FRD = np.array([1.0, 0.0, 0.0, 0.0])
+# Note: this quaternion follows the convention [qw, qx, qy, qz]
+# q_FLU_to_FRD -> [0.0, 1.0, 0.0, 0.0]
 
-# A scipe rotation from the FLU body frame to the FRD body frame
-rot_FLU_to_FRD = Rotation.from_quat(q_FLU_to_FRD)
+# Rotation from the FLU body frame to the FRD body frame
+def rot_FLU_to_FRD(device, dtype):
+    q_FLU_to_FRD = torch.tensor([0.0, 1.0, 0.0, 0.0], dtype=torch.float32, device=device)
+    return transforms.quaternion_to_matrix(q_FLU_to_FRD)
+

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/barometer.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/barometer.py
@@ -7,7 +7,8 @@
 """
 __all__ = ["Barometer"]
 
-import numpy as np
+#import numpy as np
+import torch
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.sensors import Sensor
 from pegasus.simulator.logic.sensors.geo_mag_utils import GRAVITY_VECTOR
@@ -18,7 +19,7 @@ class Barometer(Sensor):
     """The class that implements a barometer sensor. This class inherits the base class Sensor.
     """
 
-    def __init__(self, config={}):
+    def __init__(self, config={}, device="cpu"):
         """Initialize the Barometer class
 
         Args:
@@ -35,9 +36,12 @@ class Barometer(Sensor):
             >>>  "drift_pa_per_sec": 0.0,             # Pa
             >>>  "update_rate": 250.0}                # Hz
         """
-
+        
         # Initialize the Super class "object" attributes
-        super().__init__(sensor_type="Barometer", update_rate=config.get("update_rate", 250.0))
+        super().__init__(sensor_type="Barometer", update_rate=torch.tensor(config.get("update_rate", 250.0), dtype=torch.float32, device=device))
+
+        # Set device
+        self.device = device
 
         self._z_start: float = None
 
@@ -48,25 +52,29 @@ class Barometer(Sensor):
 
         # Define the constants for the barometer
         # International standard atmosphere (troposphere model - valid up to 11km) see [1]
-        self._TEMPERATURE_MSL: float = config.get("temperature_msl", 288.15)  # temperature at MSL [K] (15 [C])
-        self._PRESSURE_MSL: float = config.get("pressure_msl", 101325.0)  # pressure at MSL [Pa]
-        self._LAPSE_RATE: float = config.get(
+        self._TEMPERATURE_MSL: torch.Tensor = torch.tensor(config.get("temperature_msl", 288.15), dtype=torch.float32, device=device)  # temperature at MSL [K] (15 [C])
+        self._PRESSURE_MSL: torch.Tensor = torch.tensor(config.get("pressure_msl", 101325.0), dtype=torch.float32, device=device)  # pressure at MSL [Pa]
+        self._LAPSE_RATE: torch.Tensor = torch.tensor(config.get(
             "lapse_rate", 0.0065
-        )  # reduction in temperature with altitude for troposphere [K/m]
-        self._AIR_DENSITY_MSL: float = config.get("air_density_msl", 1.225)  # air density at MSL [kg/m^3]
-        self._ABSOLUTE_ZERO_C: float = config.get("absolute_zero", -273.15)  # [C]
+        ), dtype=torch.float32, device=device)  # reduction in temperature with altitude for troposphere [K/m]
+        self._AIR_DENSITY_MSL: torch.Tensor = torch.tensor(config.get("air_density_msl", 1.225), dtype=torch.float32, device=device)  # air density at MSL [kg/m^3]
+        self._ABSOLUTE_ZERO_C: torch.Tensor = torch.tensor(config.get("absolute_zero", -273.15), dtype=torch.float32, device=device)  # [C]
 
         # Set the drift for the sensor
-        self._baro_drift_pa_per_sec: float = config.get("drift_pa_per_sec", 0.0)
+        self._baro_drift_pa_per_sec: torch.Tensor = torch.tensor(config.get("drift_pa_per_sec", 0.0), dtype=torch.float32, device=device)
 
         # Auxiliar variables for generating the noise
         self._baro_rnd_use_last: bool = False
-        self._baro_rnd_y2: float = 0.0
-        self._baro_drift_pa: float = 0.0
+        self._baro_rnd_y2: torch.Tensor = torch.tensor(0.0, dtype=torch.float32, device=device)
+        self._baro_drift_pa: torch.Tensor = torch.tensor(0.0, dtype=torch.float32, device=device)
         
 
         # Save the current state measured by the Baramoter
-        self._state = {"absolute_pressure": 0.0, "pressure_altitude": 0.0, "temperature": 0.0}
+        self._state = {
+            "absolute_pressure": torch.tensor(0.0, dtype=torch.float32, device=device), 
+            "pressure_altitude": torch.tensor(0.0, dtype=torch.float32, device=device), 
+            "temperature": torch.tensor(0.0, dtype=torch.float32, device=device)
+        }
 
     @property
     def state(self):
@@ -76,14 +84,14 @@ class Barometer(Sensor):
         return self._state
 
     @Sensor.update_at_rate
-    def update(self, state: State, dt: float):
+    def update(self, state: State, dt: torch.Tensor):
         """Method that implements the logic of a barometer. In this method we compute the relative altitude of the vehicle
         relative to the origin's altitude. Aditionally, we compute the actual altitude of the vehicle, local temperature and
         absolute presure, based on the reference - [A brief summary of atmospheric modeling, Cavcar, M., http://fisicaatmo.at.fcen.uba.ar/practicas/ISAweb.pdf]
 
         Args:
             state (State): The current state of the vehicle.
-            dt (float): The time elapsed between the previous and current function calls (s).
+            dt (torch.Tensor): The time elapsed between the previous and current function calls (s).
 
         Returns:
             (dict) A dictionary containing the current state of the sensor (the data produced by the sensor)
@@ -94,51 +102,52 @@ class Barometer(Sensor):
             self._z_start = state.position[2]
 
         # Compute the temperature at the current altitude
-        alt_rel: float = state.position[2] - self._z_start
-        alt_amsl: float = self._origin_alt + alt_rel
-        temperature_local: float = self._TEMPERATURE_MSL - self._LAPSE_RATE * alt_amsl
+        alt_rel: torch.Tensor = state.position[2] - self._z_start
+        alt_amsl: torch.Tensor = self._origin_alt + alt_rel
+        temperature_local: torch.Tensor = self._TEMPERATURE_MSL - self._LAPSE_RATE * alt_amsl
 
         # Compute the absolute pressure at local temperature
-        pressure_ratio: float = np.power(self._TEMPERATURE_MSL / temperature_local, 5.2561)
-        absolute_pressure: float = self._PRESSURE_MSL / pressure_ratio
+        pressure_ratio: torch.Tensor = torch.pow(self._TEMPERATURE_MSL / temperature_local, 5.2561)
+        absolute_pressure: torch.Tensor = self._PRESSURE_MSL / pressure_ratio
 
         # Generate a Gaussian noise sequence using polar form of Box-Muller transformation
         # Honestly, this is overkill and will get replaced by numpys random.randn. 
         if not self._baro_rnd_use_last:
 
-            w: float = 1.0
+            w: torch.Tensor = torch.tensor(1.0, dtype=torch.float32, device=self.device)
 
             while w >= 1.0:
-                x1: float = 2.0 * np.random.randn() - 1.0
-                x2: float = 2.0 * np.random.randn() - 1.0
+                x1: torch.Tensor = torch.tensor(2.0, dtype=torch.float32, device=self.device) * torch.randn((), device=self.device) - torch.tensor(1.0, dtype=torch.float32, device=self.device)
+                x2: torch.Tensor = torch.tensor(2.0, dtype=torch.float32, device=self.device) * torch.randn((), device=self.device) - torch.tensor(1.0, dtype=torch.float32, device=self.device)
                 w = (x1 * x1) + (x2 * x2)
 
-            w = np.sqrt((-2.0 * np.log(w)) / w)
-            y1: float = x1 * w
+            w = torch.sqrt((-2.0 * torch.log(w)) / w)
+            y1: torch.Tensor = x1 * w
             self._baro_rnd_y2 = x2 * w
             self._baro_rnd_use_last = True
         else:
-            y1: float = self._baro_rnd_y2
+            y1: torch.Tensor = self._baro_rnd_y2
             self._baro_rnd_use_last = False
 
         # Apply noise and drift
-        abs_pressure_noise: float = y1  # 1 Pa RMS noise
+        abs_pressure_noise: torch.Tensor = y1  # 1 Pa RMS noise
         self._baro_drift_pa = self._baro_drift_pa + (self._baro_drift_pa_per_sec * dt)  # Update the drift
-        absolute_pressure_noisy: float = absolute_pressure + abs_pressure_noise + self._baro_drift_pa_per_sec
+        absolute_pressure_noisy: torch.Tensor = absolute_pressure + abs_pressure_noise + self._baro_drift_pa_per_sec
 
         # Convert to hPa (Note: 1 hPa = 100 Pa)
-        absolute_pressure_noisy_hpa: float = absolute_pressure_noisy * 0.01
+        absolute_pressure_noisy_hpa: torch.Tensor = absolute_pressure_noisy * 0.01
 
         # Compute air density at local temperature
-        density_ratio: float = np.power(self._TEMPERATURE_MSL / temperature_local, 4.256)
-        air_density: float = self._AIR_DENSITY_MSL / density_ratio
+        density_ratio: torch.Tensor = torch.pow(self._TEMPERATURE_MSL / temperature_local, 4.256)
+        air_density: torch.Tensor = self._AIR_DENSITY_MSL / density_ratio
 
         # Compute pressure altitude including effect of pressure noise
-        pressure_altitude: float = alt_amsl - (abs_pressure_noise + self._baro_drift_pa) / (np.linalg.norm(GRAVITY_VECTOR) * air_density)
-        #pressure_altitude: float = alt_amsl - (abs_pressure_noise) / (np.linalg.norm(GRAVITY_VECTOR) * air_density)
+        gravity_norm = torch.linalg.norm(torch.tensor(GRAVITY_VECTOR, dtype=torch.float32, device=self.device))
+        pressure_altitude: torch.Tensor = alt_amsl - (abs_pressure_noise + self._baro_drift_pa) / (gravity_norm * air_density)
+        #pressure_altitude: torch.Tensor = alt_amsl - (abs_pressure_noise) / (torch.linalg.norm(GRAVITY_VECTOR) * air_density)
 
         # Compute temperature in celsius
-        temperature_celsius: float = temperature_local + self._ABSOLUTE_ZERO_C
+        temperature_celsius: torch.Tensor = temperature_local + self._ABSOLUTE_ZERO_C
 
         # Add the values to the dictionary and return it
         self._state = {

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/geo_mag_utils.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/geo_mag_utils.py
@@ -5,7 +5,8 @@ given the position of the vehicle in the simulated world. These computations and
 with the PX4 stil_gazebo implementation (https://github.com/PX4/PX4-SITL_gazebo). Therefore, PX4 should behave similarly 
 to a gazebo-based simulation.
 """
-import numpy as np
+#import numpy as np
+import torch
 
 # Declare which functions are visible from this file
 __all__ = ["get_mag_declination", "get_mag_inclination", "get_mag_strength", "reprojection", "GRAVITY_VECTOR"]
@@ -71,43 +72,55 @@ SAMPLING_MAX_LON = 180  # deg
 EARTH_RADIUS = 6353000.0  # meters
 
 # Gravity vector expressed in ENU
-GRAVITY_VECTOR = np.array([0.0, 0.0, -9.80665])  # m/s^2
+GRAVITY_VECTOR = [0.0, 0.0, -9.80665]  # m/s^2
+
+# Base CPU tensors; moved/cast on demand
+_DECLINATION_TABLE_T = torch.tensor(DECLINATION_TABLE, dtype=torch.float32)
+_INCLINATION_TABLE_T = torch.tensor(INCLINATION_TABLE, dtype=torch.float32)
+_STRENGTH_TABLE_T = torch.tensor(STRENGTH_TABLE, dtype=torch.float32)
 
 
-def get_lookup_table_index(val: int, min: int, max: int):
+def get_lookup_table_index(val: torch.Tensor, min_val: int, max_val: int):
 
     # for the rare case of hitting the bounds exactly
     # the rounding logic wouldn't fit, so enforce it.
     # limit to table bounds - required for maxima even when table spans full globe range
     # limit to (table bounds - 1) because bilinear interpolation requires checking (index + 1)
-    val = np.clip(val, min, max - SAMPLING_RES)
-    return int((-min + val) / SAMPLING_RES)
+
+    min_val = torch.as_tensor(min_val, dtype=val.dtype, device=val.device)
+    max_val = torch.as_tensor(max_val, dtype=val.dtype, device=val.device)
+
+    val = torch.clamp(val, min_val, max_val - SAMPLING_RES)
+
+    return ((-min_val + val) / SAMPLING_RES).long()
 
 
-def get_table_data(lat: float, lon: float, table):
+def get_table_data(lat: torch.Tensor, lon: torch.Tensor, table):
 
     # If the values exceed valid ranges, return zero as default
     # as we have no way of knowing what the closest real value
     # would be.
-    if lat < -90.0 or lat > 90.0 or lon < -180.0 or lon > 180.0:
-        return 0.0
+    if ((lat < -90.0) | (lat > 90.0) | (lon < -180.0) | (lon > 180.0)).item():
+        return torch.tensor(0.0, dtype=lat.dtype, device=lat.device)
 
     # round down to nearest sampling resolution
-    min_lat = int(lat / SAMPLING_RES) * SAMPLING_RES
-    min_lon = int(lon / SAMPLING_RES) * SAMPLING_RES
+    min_lat = torch.floor(lat / SAMPLING_RES) * SAMPLING_RES
+    min_lon = torch.floor(lon / SAMPLING_RES) * SAMPLING_RES
 
     # find index of nearest low sampling point
     min_lat_index = get_lookup_table_index(min_lat, SAMPLING_MIN_LAT, SAMPLING_MAX_LAT)
     min_lon_index = get_lookup_table_index(min_lon, SAMPLING_MIN_LON, SAMPLING_MAX_LON)
 
-    data_sw = table[min_lat_index][min_lon_index]
-    data_se = table[min_lat_index][min_lon_index + 1]
-    data_ne = table[min_lat_index + 1][min_lon_index + 1]
-    data_nw = table[min_lat_index + 1][min_lon_index]
+    table = table.to(device=lat.device, dtype=lat.dtype)
+
+    data_sw = table[min_lat_index, min_lon_index]
+    data_se = table[min_lat_index, min_lon_index + 1]
+    data_ne = table[min_lat_index + 1, min_lon_index + 1]
+    data_nw = table[min_lat_index + 1, min_lon_index]
 
     # perform bilinear interpolation on the four grid corners
-    lat_scale = np.clip((lat - min_lat) / SAMPLING_RES, 0.0, 1.0)
-    lon_scale = np.clip((lon - min_lon) / SAMPLING_RES, 0.0, 1.0)
+    lat_scale = torch.clamp((lat - min_lat) / SAMPLING_RES, 0.0, 1.0)
+    lon_scale = torch.clamp((lon - min_lon) / SAMPLING_RES, 0.0, 1.0)
 
     data_min = lon_scale * (data_se - data_sw) + data_sw
     data_max = lon_scale * (data_ne - data_nw) + data_nw
@@ -115,33 +128,36 @@ def get_table_data(lat: float, lon: float, table):
     return lat_scale * (data_max - data_min) + data_min
 
 
-def get_mag_declination(latitude: float, longitude: float):
-    return get_table_data(latitude, longitude, DECLINATION_TABLE)
+def get_mag_declination(latitude: torch.Tensor, longitude: torch.Tensor):
+    return get_table_data(latitude, longitude, _DECLINATION_TABLE_T)
 
 
-def get_mag_inclination(latitude: float, longitude: float):
-    return get_table_data(latitude, longitude, INCLINATION_TABLE)
+def get_mag_inclination(latitude: torch.Tensor, longitude: torch.Tensor):
+    return get_table_data(latitude, longitude, _INCLINATION_TABLE_T)
 
 
-def get_mag_strength(latitude: float, longitude: float):
-    return get_table_data(latitude, longitude, STRENGTH_TABLE)
+def get_mag_strength(latitude: torch.Tensor, longitude: torch.Tensor):
+    return get_table_data(latitude, longitude, _STRENGTH_TABLE_T)
 
 
-def reprojection(position: np.ndarray, origin_lat=-999, origin_long=-999):
+def reprojection(position: torch.Tensor, origin_lat=-999, origin_long=-999):
     """
     Compute the latitude and longitude coordinates from a local position
     """
 
-    # reproject local position to gps coordinates
-    x_rad: float = position[1] / EARTH_RADIUS  # north
-    y_rad: float = position[0] / EARTH_RADIUS  # east
-    c: float = np.sqrt(x_rad * x_rad + y_rad * y_rad)
-    sin_c: float = np.sin(c)
-    cos_c: float = np.cos(c)
+    origin_lat = torch.as_tensor(origin_lat, dtype=position.dtype, device=position.device)
+    origin_long = torch.as_tensor(origin_long, dtype=position.dtype, device=position.device)
 
-    if c != 0.0:
-        latitude_rad = np.arcsin(cos_c * np.sin(origin_lat) + (x_rad * sin_c * np.cos(origin_lat)) / c)
-        longitude_rad = origin_long + np.arctan2(y_rad * sin_c, c * np.cos(origin_lat) * cos_c - x_rad * np.sin(origin_lat) * sin_c)
+    # reproject local position to gps coordinates
+    x_rad: torch.Tensor = position[1] / EARTH_RADIUS  # north
+    y_rad: torch.Tensor = position[0] / EARTH_RADIUS  # east
+    c: torch.Tensor = torch.sqrt(x_rad * x_rad + y_rad * y_rad)
+    sin_c: torch.Tensor = torch.sin(c)
+    cos_c: torch.Tensor = torch.cos(c)
+
+    if c.item() != 0.0:
+        latitude_rad = torch.arcsin(cos_c * torch.sin(origin_lat) + (x_rad * sin_c * torch.cos(origin_lat)) / c)
+        longitude_rad = origin_long + torch.arctan2(y_rad * sin_c, c * torch.cos(origin_lat) * cos_c - x_rad * torch.sin(origin_lat) * sin_c)
     else:
         latitude_rad = origin_lat
         longitude_rad = origin_long

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/gps.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/gps.py
@@ -6,7 +6,9 @@
 """
 __all__ = ["GPS"]
 
-import numpy as np
+#import numpy as np
+import torch
+
 from pegasus.simulator.logic.sensors import Sensor
 from pegasus.simulator.logic.sensors.geo_mag_utils import reprojection
 
@@ -16,7 +18,7 @@ class GPS(Sensor):
     """The class that implements a GPS sensor. This class inherits the base class Sensor.
     """
 
-    def __init__(self, config={}):
+    def __init__(self, config={}, device="cpu"):
         """Initialize the GPS class.
 
         Args:
@@ -40,53 +42,54 @@ class GPS(Sensor):
             >>> }
         """
 
+        # Set device
+        self.device = device
+
         # Initialize the Super class "object" attributes
-        super().__init__(sensor_type="GPS", update_rate=config.get("update_rate", 250.0))
+        super().__init__(sensor_type="GPS", update_rate=torch.tensor(config.get("update_rate", 250.0), dtype=torch.float32, device=device))
 
         # Define the GPS simulated/fixed values
-        self._fix_type = config.get("fix_type", 3)
-        self._eph = config.get("eph", 1.0)
-        self._epv = config.get("epv", 1.0)
-        self._sattelites_visible = config.get("sattelites_visible", 10)
+        self._fix_type = torch.tensor(config.get("fix_type", 3), dtype=torch.int32, device=device)
+        self._eph = torch.tensor(config.get("eph", 1.0), dtype=torch.float32, device=device)
+        self._epv = torch.tensor(config.get("epv", 1.0), dtype=torch.float32, device=device)
+        self._sattelites_visible = torch.tensor(config.get("sattelites_visible", 10), dtype=torch.int32, device=device)
 
         # Parameters for GPS random walk
-        self._random_walk_gps = np.array([0.0, 0.0, 0.0])
-        self._gps_xy_random_walk = config.get("gps_xy_random_walk", 2.0)  # (m/s) / sqrt(hz)
-        self._gps_z_random_walk = config.get("gps_z_random_walk", 4.0)  # (m/s) / sqrt(hz)
+        self._random_walk_gps = torch.zeros(3, dtype=torch.float32, device=device)
+        self._gps_xy_random_walk = torch.tensor(config.get("gps_xy_random_walk", 2.0), dtype=torch.float32, device=device)  # (m/s) / sqrt(hz)
+        self._gps_z_random_walk = torch.tensor(config.get("gps_z_random_walk", 4.0), dtype=torch.float32, device=device)  # (m/s) / sqrt(hz)
 
         # Parameters for the position noise
-        self._noise_gps_pos = np.array([0.0, 0.0, 0.0])
-        self._gps_xy_noise_density = config.get("gps_xy_noise_density", 2.0e-4)  # (m) / sqrt(hz)
-        self._gps_z_noise_density = config.get("gps_z_noise_density", 4.0e-4)  # (m) / sqrt(hz)
+        self._noise_gps_pos = torch.zeros(3, dtype=torch.float32, device=device)
+        self._gps_xy_noise_density = torch.tensor(config.get("gps_xy_noise_density", 2.0e-4), dtype=torch.float32, device=device)  # (m) / sqrt(hz)
+        self._gps_z_noise_density = torch.tensor(config.get("gps_z_noise_density", 4.0e-4), dtype=torch.float32, device=device)  # (m) / sqrt(hz)
 
         # Parameters for the velocity noise
-        self._noise_gps_vel = np.array([0.0, 0.0, 0.0])
-        self._gps_vxy_noise_density = config.get("gps_vxy_noise_density", 0.2)  # (m/s) / sqrt(hz)
-        self._gps_vz_noise_density = config.get("gps_vz_noise_density", 0.4)  # (m/s) / sqrt(hz)
+        self._noise_gps_vel = torch.zeros(3, dtype=torch.float32, device=device)
+        self._gps_vxy_noise_density = torch.tensor(config.get("gps_vxy_noise_density", 0.2), dtype=torch.float32, device=device)  # (m/s) / sqrt(hz)
+        self._gps_vz_noise_density = torch.tensor(config.get("gps_vz_noise_density", 0.4), dtype=torch.float32, device=device)  # (m/s) / sqrt(hz)
 
         # Parameters for the GPS bias
-        self._gps_bias = np.array([0.0, 0.0, 0.0])
-        self._gps_correlation_time = config.get("gps_correlation_time", 60)
+        self._gps_bias = torch.zeros(3, dtype=torch.float32, device=device)
+        self._gps_correlation_time = torch.tensor(config.get("gps_correlation_time", 60), dtype=torch.float32, device=device)
 
         # Save the current state measured by the GPS (and initialize at the origin)
         self._state = {
-            "latitude": np.radians(self._origin_lat),
-            "longitude": np.radians(self._origin_lon),
+            "latitude": torch.deg2rad(self._origin_lat),
+            "longitude": torch.deg2rad(self._origin_lon),
             "altitude": self._origin_alt,
-            "eph": 1.0,
-            "epv": 1.0,
-            "speed": 0.0,
-            "velocity_north": 0.0,
-            "velocity_east": 0.0,
-            "velocity_down": 0.0,
+            "speed": torch.tensor(0.0, dtype=torch.float32, device=device),
+            "velocity_north": torch.tensor(0.0, dtype=torch.float32, device=device),
+            "velocity_east": torch.tensor(0.0, dtype=torch.float32, device=device),
+            "velocity_down": torch.tensor(0.0, dtype=torch.float32, device=device),
             # Constant values
             "fix_type": self._fix_type,
             "eph": self._eph,
             "epv": self._epv,
-            "cog": 0.0,
+            "cog": torch.tensor(0.0, dtype=torch.float32, device=device),
             "sattelites_visible": self._sattelites_visible,
-            "latitude_gt": np.radians(self._origin_lat),
-            "longitude_gt": np.radians(self._origin_lon),
+            "latitude_gt": torch.deg2rad(self._origin_lat),
+            "longitude_gt": torch.deg2rad(self._origin_lon),
             "altitude_gt": self._origin_alt,
         }
 
@@ -98,7 +101,7 @@ class GPS(Sensor):
         return self._state
 
     @Sensor.update_at_rate
-    def update(self, state: np.ndarray, dt: float):
+    def update(self, state: torch.Tensor, dt: torch.Tensor):
         """Method that implements the logic of a gps. In this method we start by generating the GPS bias terms which are then
         added to the real position of the vehicle, expressed in ENU inertial frame. This position affected by noise
         is reprojected in order to obtain the corresponding latitude and longitude. Additionally, to the linear velocity, noise
@@ -106,24 +109,24 @@ class GPS(Sensor):
 
         Args:
             state (State): The current state of the vehicle.
-            dt (float): The time elapsed between the previous and current function calls (s).
+            dt (torch.Tensor): The time elapsed between the previous and current function calls (s).
 
         Returns:
             (dict) A dictionary containing the current state of the sensor (the data produced by the sensor)
         """
 
         # Update noise parameters
-        self._random_walk_gps[0] = self._gps_xy_random_walk * np.sqrt(dt) * np.random.randn()
-        self._random_walk_gps[1] = self._gps_xy_random_walk * np.sqrt(dt) * np.random.randn()
-        self._random_walk_gps[2] = self._gps_z_random_walk * np.sqrt(dt) * np.random.randn()
+        self._random_walk_gps[0] = self._gps_xy_random_walk * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._random_walk_gps[1] = self._gps_xy_random_walk * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._random_walk_gps[2] = self._gps_z_random_walk * torch.sqrt(dt) * torch.randn((), device=self.device)
 
-        self._noise_gps_pos[0] = self._gps_xy_noise_density * np.sqrt(dt) * np.random.randn()
-        self._noise_gps_pos[1] = self._gps_xy_noise_density * np.sqrt(dt) * np.random.randn()
-        self._noise_gps_pos[2] = self._gps_z_noise_density * np.sqrt(dt) * np.random.randn()
+        self._noise_gps_pos[0] = self._gps_xy_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._noise_gps_pos[1] = self._gps_xy_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._noise_gps_pos[2] = self._gps_z_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
 
-        self._noise_gps_vel[0] = self._gps_vxy_noise_density * np.sqrt(dt) * np.random.randn()
-        self._noise_gps_vel[1] = self._gps_vxy_noise_density * np.sqrt(dt) * np.random.randn()
-        self._noise_gps_vel[2] = self._gps_vz_noise_density * np.sqrt(dt) * np.random.randn()
+        self._noise_gps_vel[0] = self._gps_vxy_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._noise_gps_vel[1] = self._gps_vxy_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
+        self._noise_gps_vel[2] = self._gps_vz_noise_density * torch.sqrt(dt) * torch.randn((), device=self.device)
 
         # Perform GPS bias integration (using euler integration -> to be improved)
         self._gps_bias[0] = (
@@ -137,38 +140,36 @@ class GPS(Sensor):
         )
 
         # reproject position with noise into geographic coordinates
-        pos_with_noise: np.ndarray = state.position + self._noise_gps_pos + self._gps_bias
-        latitude, longitude = reprojection(pos_with_noise, np.radians(self._origin_lat), np.radians(self._origin_lon))
+        pos_with_noise: torch.Tensor = state.position + self._noise_gps_pos + self._gps_bias
+        latitude, longitude = reprojection(pos_with_noise, torch.deg2rad(self._origin_lat), torch.deg2rad(self._origin_lon))
 
         # Compute the values of the latitude and longitude without noise (for groundtruth measurements)
         latitude_gt, longitude_gt = reprojection(
-            state.position, np.radians(self._origin_lat), np.radians(self._origin_lon)
+            state.position, torch.deg2rad(self._origin_lat), torch.deg2rad(self._origin_lon)
         )
 
         # Add noise to the velocity expressed in the world frame
-        velocity: np.ndarray = state.linear_velocity  # + self._noise_gps_vel
+        velocity: torch.Tensor = state.linear_velocity  # + self._noise_gps_vel
 
         # Compute the xy speed
-        speed: float = np.linalg.norm(velocity[:2])
+        speed: torch.Tensor = torch.linalg.norm(velocity[:2])
 
         # Course over ground (NOT heading, but direction of movement),
         # 0.0..359.99 degrees. If unknown, set to: 65535 [cdeg] (type:uint16_t)
         ve = velocity[0]
         vn = velocity[1]
-        cog = np.degrees(np.arctan2(ve, vn))
+        cog = torch.rad2deg(torch.arctan2(ve, vn))
 
-        if cog < 0.0:
+        if (cog < 0.0).item():
             cog = cog + 360.0
 
         cog = cog * 100
 
         # Add the values to the dictionary and return it
         self._state = {
-            "latitude": np.degrees(latitude),
-            "longitude": np.degrees(longitude),
+            "latitude": torch.rad2deg(latitude),
+            "longitude": torch.rad2deg(longitude),
             "altitude": state.position[2] + self._origin_alt - self._noise_gps_pos[2] + self._gps_bias[2],
-            "eph": 1.0,
-            "epv": 1.0,
             "speed": speed,
             # Conversion from ENU (standard of Isaac Sim to NED - used in GPS sensors)
             "velocity_north": velocity[1],
@@ -178,7 +179,7 @@ class GPS(Sensor):
             "fix_type": self._fix_type,
             "eph": self._eph,
             "epv": self._epv,
-            "cog": 0.0,  # cog,
+            "cog": torch.tensor(0.0, dtype=torch.float32, device=self.device),  # cog,
             "sattelites_visible": self._sattelites_visible,
             "latitude_gt": latitude_gt,
             "longitude_gt": longitude_gt,

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/imu.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/imu.py
@@ -6,8 +6,11 @@
 """
 __all__ = ["IMU"]
 
-import numpy as np
-from scipy.spatial.transform import Rotation
+#import numpy as np
+import torch
+
+#from scipy.spatial.transform import Rotation
+import pytorch3d.transforms as transforms
 
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.sensors import Sensor
@@ -18,7 +21,7 @@ from pegasus.simulator.logic.sensors.geo_mag_utils import GRAVITY_VECTOR
 class IMU(Sensor):
     """The class that implements the IMU sensor. This class inherits the base class Sensor.
     """
-    def __init__(self, config={}):
+    def __init__(self, config={}, device="cpu"):
         """Initialize the IMU class
 
         Args:
@@ -42,35 +45,72 @@ class IMU(Sensor):
         """
 
         # Initialize the Super class "object" attributes
-        super().__init__(sensor_type="IMU", update_rate=config.get("update_rate", 250.0))
+        super().__init__(sensor_type="IMU", update_rate=torch.tensor(config.get("update_rate", 250.0), dtype=torch.float32, device=device))
+
+        # Set device
+        self.device = device
 
         # Orientation noise constant
-        self._orientation_noise: float = 0.0
+        self._orientation_noise: torch.Tensor = torch.tensor(0.0, dtype=torch.float32, device=self.device)      
 
         # Gyroscope noise constants
-        self._gyroscope_bias: np.ndarray = np.zeros((3,))
+        self._gyroscope_bias: torch.Tensor = torch.zeros(3, dtype=torch.float32, device=self.device)        
         gyroscope_config = config.get("gyroscope", {})
-        self._gyroscope_noise_density = gyroscope_config.get("noise_density", 0.0003393695767766752)
-        self._gyroscope_random_walk = gyroscope_config.get("random_walk", 3.878509448876288E-05)
-        self._gyroscope_bias_correlation_time = gyroscope_config.get("bias_correlation_time", 1.0E3)
-        self._gyroscope_turn_on_bias_sigma = gyroscope_config.get("turn_on_bias_sigma", 0.008726646259971648)
+
+        self._gyroscope_noise_density = torch.tensor(
+            gyroscope_config.get("noise_density", 0.0003393695767766752),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._gyroscope_random_walk = torch.tensor(
+            gyroscope_config.get("random_walk", 3.878509448876288e-05),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._gyroscope_bias_correlation_time = torch.tensor(
+            gyroscope_config.get("bias_correlation_time", 1.0e3),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._gyroscope_turn_on_bias_sigma = torch.tensor(
+            gyroscope_config.get("turn_on_bias_sigma", 0.008726646259971648),
+            dtype=torch.float32,
+            device=self.device
+        )
 
         # Accelerometer noise constants
-        self._accelerometer_bias: np.ndarray = np.zeros((3,))
+        self._accelerometer_bias: torch.Tensor = torch.zeros(3, dtype=torch.float32, device=self.device)
         accelerometer_config = config.get("accelerometer", {})
-        self._accelerometer_noise_density = accelerometer_config.get("noise_density", 0.004)
-        self._accelerometer_random_walk = accelerometer_config.get("random_walk", 0.006)
-        self._accelerometer_bias_correlation_time = accelerometer_config.get("bias_correlation_time", 300.0)
-        self._accelerometer_turn_on_bias_sigma = accelerometer_config.get("turn_on_bias_sigma", 0.196)
+
+        self._accelerometer_noise_density = torch.tensor(
+            accelerometer_config.get("noise_density", 0.004),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._accelerometer_random_walk = torch.tensor(
+            accelerometer_config.get("random_walk", 0.006),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._accelerometer_bias_correlation_time = torch.tensor(
+            accelerometer_config.get("bias_correlation_time", 300.0),
+            dtype=torch.float32,
+            device=self.device
+        )
+        self._accelerometer_turn_on_bias_sigma = torch.tensor(
+            accelerometer_config.get("turn_on_bias_sigma", 0.196),
+            dtype=torch.float32,
+            device=self.device
+        )
 
         # Auxiliar variable used to compute the linear acceleration of the vehicle
-        self._prev_linear_velocity = np.zeros((3,))
+        self._prev_linear_velocity: torch.Tensor = torch.zeros(3, dtype=torch.float32, device=self.device)        
 
         # Save the current state measured by the IMU
         self._state = {
-            "orientation": np.array([1.0, 0.0, 0.0, 0.0]),
-            "angular_velocity": np.array([0.0, 0.0, 0.0]),
-            "linear_acceleration": np.array([0.0, 0.0, 0.0]),
+            "orientation": torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=self.device),
+            "angular_velocity": torch.zeros(3, dtype=torch.float32, device=self.device),
+            "linear_acceleration": torch.zeros(3, dtype=torch.float32, device=self.device),
         }
 
     @property
@@ -81,7 +121,7 @@ class IMU(Sensor):
         return self._state
 
     @Sensor.update_at_rate
-    def update(self, state: State, dt: float):
+    def update(self, state: State, dt: torch.Tensor):
         """Method that implements the logic of an IMU. In this method we start by generating the random walk of the 
         gyroscope. This value is then added to the real angular velocity of the vehicle (FLU relative to ENU inertial frame
         expressed in FLU body frame). The same logic is followed for the accelerometer and the accelerations. After this step,
@@ -91,60 +131,60 @@ class IMU(Sensor):
 
         Args:
             state (State): The current state of the vehicle.
-            dt (float): The time elapsed between the previous and current function calls (s).
+            dt (torch.Tensor): The time elapsed between the previous and current function calls (s).
 
         Returns:
             (dict) A dictionary containing the current state of the sensor (the data produced by the sensor)
         """
 
         # Gyroscopic terms
-        tau_g: float = self._accelerometer_bias_correlation_time
+        tau_g: torch.Tensor = self._accelerometer_bias_correlation_time # _gyroscope_bias_correlation_time ??
 
         # Discrete-time standard deviation equivalent to an "integrating" sampler with integration time dt
-        sigma_g_d: float = 1 / np.sqrt(dt) * self._gyroscope_noise_density
-        sigma_b_g: float = self._gyroscope_random_walk
+        sigma_g_d: torch.Tensor = 1 / torch.sqrt(dt) * self._gyroscope_noise_density
+        sigma_b_g: torch.Tensor = self._gyroscope_random_walk
 
         # Compute exact covariance of the process after dt [Maybeck 4-114]
-        sigma_b_g_d: float = np.sqrt(-sigma_b_g * sigma_b_g * tau_g / 2.0 * (np.exp(-2.0 * dt / tau_g) - 1.0))
+        sigma_b_g_d: torch.Tensor = torch.sqrt(-sigma_b_g * sigma_b_g * tau_g / 2.0 * (torch.exp(-2.0 * dt / tau_g) - 1.0))
 
         # Compute state-transition
-        phi_g_d: float = np.exp(-1.0 / tau_g * dt)
+        phi_g_d: torch.Tensor = torch.exp(-1.0 / tau_g * dt)
 
         # Simulate gyroscope noise processes and add them to the true angular rate.
-        angular_velocity: np.ndarray = np.zeros((3,))
+        angular_velocity: torch.Tensor = torch.zeros(3, dtype=torch.float32, device=self.device)   
 
         for i in range(3):
-            self._gyroscope_bias[i] = phi_g_d * self._gyroscope_bias[i] + sigma_b_g_d * np.random.randn()
-            angular_velocity[i] = state.angular_velocity[i] + sigma_g_d * np.random.randn() + self._gyroscope_bias[i]
+            self._gyroscope_bias[i] = phi_g_d * self._gyroscope_bias[i] + sigma_b_g_d * torch.randn((), device=self.device)
+            angular_velocity[i] = state.angular_velocity[i] + sigma_g_d * torch.randn((), device=self.device) + self._gyroscope_bias[i]
 
         # Accelerometer terms
-        tau_a: float = self._accelerometer_bias_correlation_time
+        tau_a: torch.Tensor = self._accelerometer_bias_correlation_time
 
         # Discrete-time standard deviation equivalent to an "integrating" sampler with integration time dt
-        sigma_a_d: float = 1.0 / np.sqrt(dt) * self._accelerometer_noise_density
-        sigma_b_a: float = self._accelerometer_random_walk
+        sigma_a_d: torch.Tensor = 1.0 / torch.sqrt(dt) * self._accelerometer_noise_density
+        sigma_b_a: torch.Tensor = self._accelerometer_random_walk
 
         # Compute exact covariance of the process after dt [Maybeck 4-114].
-        sigma_b_a_d: float = np.sqrt(-sigma_b_a * sigma_b_a * tau_a / 2.0 * (np.exp(-2.0 * dt / tau_a) - 1.0))
+        sigma_b_a_d: torch.Tensor = torch.sqrt(-sigma_b_a * sigma_b_a * tau_a / 2.0 * (torch.exp(-2.0 * dt / tau_a) - 1.0))
 
         # Compute state-transition.
-        phi_a_d: float = np.exp(-1.0 / tau_a * dt)
+        phi_a_d: torch.Tensor = torch.exp(-1.0 / tau_a * dt)
 
         # Compute the linear acceleration from diferentiating the velocity of the vehicle expressed in the inertial frame
         linear_acceleration_inertial = (state.linear_velocity - self._prev_linear_velocity) / dt
-        linear_acceleration_inertial = linear_acceleration_inertial - GRAVITY_VECTOR
+        linear_acceleration_inertial = linear_acceleration_inertial - torch.tensor(GRAVITY_VECTOR, device=self.device)
 
         # Update the previous linear velocity for the next computation
         self._prev_linear_velocity = state.linear_velocity
 
         # Compute the linear acceleration of the body frame, with respect to the inertial frame, expressed in the body frame
-        linear_acceleration = np.array(Rotation.from_quat(state.attitude).inv().apply(linear_acceleration_inertial))
+        linear_acceleration = transforms.quaternion_to_matrix(state.attitude).T @ linear_acceleration_inertial
 
         # Simulate the accelerometer noise processes and add them to the true linear aceleration values
         for i in range(3):
-            self._accelerometer_bias[i] = phi_a_d * self._accelerometer_bias[i] + sigma_b_a_d * np.random.rand()
+            self._accelerometer_bias[i] = phi_a_d * self._accelerometer_bias[i] + sigma_b_a_d * torch.randn((), device=self.device)
             linear_acceleration[i] = (
-                linear_acceleration[i] + sigma_a_d * np.random.randn()
+                linear_acceleration[i] + sigma_a_d * torch.randn((), device=self.device)
             ) #+ self._accelerometer_bias[i]
 
         # TODO - Add small "noisy" to the attitude
@@ -154,19 +194,19 @@ class IMU(Sensor):
         # --------------------------------------------------------------------------------------------
 
         # Convert the orientation to the FRD-NED standard
-        attitude_flu_enu = Rotation.from_quat(state.attitude)
-        attitude_frd_enu = attitude_flu_enu * rot_FLU_to_FRD
-        attitude_frd_ned = rot_ENU_to_NED * attitude_frd_enu
+        attitude_flu_enu = transforms.quaternion_to_matrix(state.attitude)
+        attitude_frd_enu = attitude_flu_enu @ rot_FLU_to_FRD(device = self.device, dtype=torch.float32)
+        attitude_frd_ned = rot_ENU_to_NED(device = self.device, dtype=torch.float32) @ attitude_frd_enu
 
         # Convert the angular velocity from FLU to FRD standard
-        angular_velocity_frd = rot_FLU_to_FRD.apply(angular_velocity)
+        angular_velocity_frd = rot_FLU_to_FRD(device = self.device, dtype=torch.float32) @ angular_velocity
 
         # Convert the linear acceleration in the body frame from FLU to FRD standard
-        linear_acceleration_frd = rot_FLU_to_FRD.apply(linear_acceleration)
+        linear_acceleration_frd = rot_FLU_to_FRD(self.device, dtype=torch.float32) @ linear_acceleration
 
         # Add the values to the dictionary and return it
         self._state = {
-            "orientation": attitude_frd_ned.as_quat(),
+            "orientation": transforms.matrix_to_quaternion(attitude_frd_ned),
             "angular_velocity": angular_velocity_frd,
             "linear_acceleration": linear_acceleration_frd,
         }

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/magnetometer.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/magnetometer.py
@@ -5,8 +5,11 @@
 """
 __all__ = ["Magnetometer"]
 
-import numpy as np
-from scipy.spatial.transform import Rotation
+#import numpy as np
+import torch
+
+#from scipy.spatial.transform import Rotation
+import pytorch3d.transforms as transforms
 
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.sensors import Sensor
@@ -22,7 +25,7 @@ class Magnetometer(Sensor):
     """The class that implements a magnetometer sensor. This class inherits the base class Sensor.
     """
 
-    def __init__(self, config={}):
+    def __init__(self, config={}, device="cpu"):
         """Initialize the Magnetometer class
 
         Args:
@@ -38,16 +41,19 @@ class Magnetometer(Sensor):
         """
 
         # Initialize the Super class "object" attributes
-        super().__init__(sensor_type="Magnetometer", update_rate=config.get("update_rate", 250.0))
+        super().__init__(sensor_type="Magnetometer", update_rate=torch.tensor(config.get("update_rate", 250.0), dtype=torch.float32, device=device))
 
+        # Set device
+        self.device = device
+        
         # Set the noise parameters
-        self._bias: np.ndarray = np.array([0.0, 0.0, 0.0])
-        self._noise_density = config.get("noise_density", 0.4e-3)  # gauss / sqrt(hz)
-        self._random_walk = config.get("random_walk", 6.4e-6)  # gauss * sqrt(hz)
-        self._bias_correlation_time = config.get("bias_correlation_time", 6.0e2)  # s
+        self._bias: torch.Tensor = torch.zeros(3, dtype=torch.float32, device=self.device)
+        self._noise_density = torch.tensor(config.get("noise_density", 0.4e-3), dtype=torch.float32, device=self.device)  # gauss / sqrt(hz)
+        self._random_walk = torch.tensor(config.get("random_walk", 6.4e-6), dtype=torch.float32, device=self.device)  # gauss * sqrt(hz)
+        self._bias_correlation_time = torch.tensor(config.get("bias_correlation_time", 6.0e2), dtype=torch.float32, device=self.device)  # s
 
         # Initial state measured by the Magnetometer
-        self._state = {"magnetic_field": np.zeros((3,))}
+        self._state = {"magnetic_field": torch.zeros(3, dtype=torch.float32, device=self.device)}
 
     @property
     def state(self):
@@ -57,7 +63,7 @@ class Magnetometer(Sensor):
         return self._state
 
     @Sensor.update_at_rate
-    def update(self, state: State, dt: float):
+    def update(self, state: State, dt: torch.Tensor):
         """Method that implements the logic of a magnetometer. In this method we start by computing the projection
         of the vehicle body frame such in the elipsoidal model of the earth in order to get its current latitude and 
         longitude. From here the declination and inclination are computed and used to get the strength of the magnetic
@@ -67,40 +73,39 @@ class Magnetometer(Sensor):
 
         Args:
             state (State): The current state of the vehicle.
-            dt (float): The time elapsed between the previous and current function calls (s).
+            dt (torch.Tensor): The time elapsed between the previous and current function calls (s).
 
         Returns:
             (dict) A dictionary containing the current state of the sensor (the data produced by the sensor)
         """
-
         # Get the latitude and longitude from the current state
-        latitude, longitude = reprojection(state.position, np.radians(self._origin_lat), np.radians(self._origin_lon))
+        latitude, longitude = reprojection(state.position, torch.deg2rad(self._origin_lat), torch.deg2rad(self._origin_lon))
 
         # Magnetic declination and inclination (radians)
-        declination_rad: float = np.radians(get_mag_declination(np.degrees(latitude), np.degrees(longitude)))
-        inclination_rad: float = np.radians(get_mag_inclination(np.degrees(latitude), np.degrees(longitude)))
+        declination_rad: torch.Tensor = torch.deg2rad(get_mag_declination(torch.rad2deg(latitude), torch.rad2deg(longitude)))
+        inclination_rad: torch.Tensor = torch.deg2rad(get_mag_inclination(torch.rad2deg(latitude), torch.rad2deg(longitude)))
 
         # Compute the magnetic strength (10^5xnanoTesla)
-        strength_ga: float = 0.01 * get_mag_strength(np.degrees(latitude), np.degrees(longitude))
+        strength_ga: torch.Tensor = 0.01 * get_mag_strength(torch.rad2deg(latitude), torch.rad2deg(longitude))
 
         # Compute the Magnetic filed components according to: http://geomag.nrcan.gc.ca/mag_fld/comp-en.php
-        H: float = strength_ga * np.cos(inclination_rad)
-        Z: float = np.tan(inclination_rad) * H
-        X: float = H * np.cos(declination_rad)
-        Y: float = H * np.sin(declination_rad)
+        H: torch.Tensor = strength_ga * torch.cos(inclination_rad)
+        Z: torch.Tensor = torch.tan(inclination_rad) * H
+        X: torch.Tensor = H * torch.cos(declination_rad)
+        Y: torch.Tensor = H * torch.sin(declination_rad)
 
         # Magnetic field of a body following a front-left-up (FLU) convention expressed in a East-North-Up (ENU) inertial frame
-        magnetic_field_inertial: np.ndarray = np.array([X, Y, Z])
+        magnetic_field_inertial: torch.Tensor = torch.stack([X, Y, Z]).to(dtype=torch.float32, device=self.device)
 
         # Rotate the magnetic field vector such that it expresses a field of a body frame according to the front-right-down (FRD)
         # expressed in a North-East-Down (NED) inertial frame (the standard used in magnetometer units)
-        attitude_flu_enu = Rotation.from_quat(state.attitude)
+        attitude_flu_enu = transforms.quaternion_to_matrix(state.attitude)
 
         # Rotate the magnetic field from the inertial frame to the body frame of reference according to the FLU frame convention
-        rot_body_to_world = rot_ENU_to_NED * attitude_flu_enu * rot_FLU_to_FRD.inv()
+        rot_body_to_world = rot_ENU_to_NED(device=self.device, dtype=torch.float32) @ attitude_flu_enu @ rot_FLU_to_FRD(device=self.device, dtype=torch.float32).T
 
         # The magnetic field expressed in the body frame according to the front-right-down (FRD) convention
-        magnetic_field_body = rot_body_to_world.inv().apply(magnetic_field_inertial)
+        magnetic_field_body = rot_body_to_world.T @ magnetic_field_inertial
 
         # -------------------------------
         # Add noise to the magnetic field
@@ -108,22 +113,22 @@ class Magnetometer(Sensor):
         tau = self._bias_correlation_time
 
         # Discrete-time standard deviation equivalent to an "integrating" sampler with integration time dt.
-        sigma_d: float = 1 / np.sqrt(dt) * self._noise_density
-        sigma_b: float = self._random_walk
+        sigma_d: torch.Tensor = 1 / torch.sqrt(dt) * self._noise_density
+        sigma_b: torch.Tensor = self._random_walk
 
         # Compute exact covariance of the process after dt [Maybeck 4-114].
-        sigma_b_d: float = np.sqrt(-sigma_b * sigma_b * tau / 2.0 * (np.exp(-2.0 * dt / tau) - 1.0))
+        sigma_b_d: torch.Tensor = torch.sqrt(-sigma_b * sigma_b * tau / 2.0 * (torch.exp(-2.0 * dt / tau) - 1.0))
 
         # Compute state-transition.
-        phi_d: float = np.exp(-1.0 / tau * dt)
+        phi_d: torch.Tensor = torch.exp(-1.0 / tau * dt)
 
         # Add the noise to the magnetic field
-        magnetic_field_noisy: np.ndarray = np.zeros((3,))
+        magnetic_field_noisy: torch.Tensor = torch.zeros((3,), device=self.device, dtype=torch.float32)
         for i in range(3):
-            self._bias[i] = phi_d * self._bias[i] + sigma_b_d * np.random.randn()
-            magnetic_field_noisy[i] = magnetic_field_body[i] + sigma_d * np.random.randn() + self._bias[i]
+            self._bias[i] = phi_d * self._bias[i] + sigma_b_d * torch.randn((), device=self.device, dtype=torch.float32)
+            magnetic_field_noisy[i] = magnetic_field_body[i] + sigma_d * torch.randn((), device=self.device, dtype=torch.float32) + self._bias[i]
 
         # Add the values to the dictionary and return it
-        self._state = {"magnetic_field": [magnetic_field_noisy[0], magnetic_field_noisy[1], magnetic_field_noisy[2]]}
+        self._state = {"magnetic_field": magnetic_field_noisy}
 
         return self._state

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/sensor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/sensors/sensor.py
@@ -5,38 +5,43 @@
 """
 __all__ = ["Sensor"]
 
+import torch
+
 from pegasus.simulator.logic.state import State
 
 class Sensor:
     """The base class for implementing a sensor
 
     Attributes:
-        update_period (float): The period for each sensor update: update_period = 1 / update_rate (in s).
-        origin_lat (float): The latitude of the origin of the world in degrees (might get used by some sensors).
-        origin_lon (float): The longitude of the origin of the world in degrees (might get used by some sensors).
-        origin_alt (float): The altitude of the origin of the world relative to sea water level (might get used by some sensors)
+        update_period (torch.Tensor): The period for each sensor update: update_period = 1 / update_rate (in s).
+        origin_lat (torch.Tensor): The latitude of the origin of the world in degrees (might get used by some sensors).
+        origin_lon (torch.Tensor): The longitude of the origin of the world in degrees (might get used by some sensors).
+        origin_alt (torch.Tensor): The altitude of the origin of the world relative to sea water level (might get used by some sensors)
     """
-    def __init__(self, sensor_type: str, update_rate: float):
+    def __init__(self, sensor_type: str, update_rate: torch.Tensor):
         """Initialize the Sensor class
 
         Args:
             sensor_type (str): A name that describes the type of sensor
-            update_rate (float): The rate at which the data in the sensor should be refreshed (in Hz)
+            update_rate (torch.Tensor): The rate at which the data in the sensor should be refreshed (in Hz)
         """
+
+        # Set device
+        self._device = update_rate.device
 
         # Set the sensor type and update rate
         self._sensor_type = sensor_type
         self._update_rate = update_rate
-        self._update_period = 1.0 / self._update_rate
+        self._update_period = torch.tensor(1.0, dtype=torch.float32, device=self._device) / self._update_rate
 
         # Auxiliar variables used to control whether to update the sensor or not given the time elapsed
         self._first_update = True
-        self._total_time = 0.0
+        self._total_time = torch.tensor(0.0, dtype=torch.float32, device=self._device)
 
         # Set the "configuration of the world" - some sensors might need it
-        self._origin_lat = -999
-        self._origin_lon = -999
-        self._origin_alt = 0.0
+        self._origin_lat = torch.tensor(-999, dtype=torch.float32, device=self._device)
+        self._origin_lon = torch.tensor(-999, dtype=torch.float32, device=self._device)
+        self._origin_alt = torch.tensor(0.0, dtype=torch.float32, device=self._device)
 
         self._vehicle = None
 
@@ -49,23 +54,23 @@ class Sensor:
         
         Args:
             vehicle (Vehicle): A reference to the vehicle that this sensor is associated with
-            origin_lat (float): The latitude of the origin of the world in degrees (might get used by some sensors).
-            origin_lon (float): The longitude of the origin of the world in degrees (might get used by some sensors).
-            origin_alt (float): The altitude of the origin of the world relative to sea water level (might get used by some sensors).
+            origin_lat (torch.Tensor): The latitude of the origin of the world in degrees (might get used by some sensors).
+            origin_lon (torch.Tensor): The longitude of the origin of the world in degrees (might get used by some sensors).
+            origin_alt (torch.Tensor): The altitude of the origin of the world relative to sea water level (might get used by some sensors).
         """
         self._vehicle = vehicle
         self._origin_lat = origin_lat
         self._origin_lon = origin_lon
         self._origin_alt = origin_alt
 
-    def set_update_rate(self, update_rate: float):
+    def set_update_rate(self, update_rate: torch.Tensor):
         """Method that changes the update rate and period of the sensor
 
         Args:
-            update_rate (float): The new rate at which the data in the sensor should be refreshed (in Hz)
+            update_rate (torch.Tensor): The new rate at which the data in the sensor should be refreshed (in Hz)
         """
         self._update_rate = update_rate
-        self._update_period = 1.0 / self._update_rate
+        self._update_period = torch.tensor(1.0, dtype=torch.float32, device=self._device) / self._update_rate
 
     def update_at_rate(fnc):
         """Decorator function used to check if the time elapsed between the last sensor update call and the current 
@@ -87,7 +92,7 @@ class Sensor:
         """
 
         # Define a wrapper function so that the "self" of the object can be passed to the function as well
-        def wrapper(self, state: State, dt: float):
+        def wrapper(self, state: State, dt: torch.Tensor):
 
             # Add the total time passed between the last time the sensor was updated and the current call
             self._total_time += dt
@@ -100,7 +105,7 @@ class Sensor:
 
                 # Reset the auxiliar counter variables
                 self._first_update = False
-                self._total_time = 0.0
+                self._total_time = torch.tensor(0.0, dtype=torch.float32, device=self._device)
 
                 return result
             return None
@@ -127,13 +132,13 @@ class Sensor:
         """
         return None
 
-    def update(self, state: State, dt: float):
+    def update(self, state: State, dt: torch.Tensor):
         """Method that should be implemented by the class that inherits Sensor. This is where the actual implementation
         of the sensor should be performed.
 
         Args:
             state (State): The current state of the vehicle.
-            dt (float): The time elapsed between the previous and current function calls (s).
+            dt (torch.Tensor): The time elapsed between the previous and current function calls (s).
 
         Returns:
             (dict) A dictionary containing the current state of the sensor (the data produced by the sensor)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/state.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/state.py
@@ -6,9 +6,16 @@
 """
 __all__ = ["State"]
 
-import numpy as np
-from scipy.spatial.transform import Rotation
-from pegasus.simulator.logic.rotations import rot_ENU_to_NED, rot_FLU_to_FRD
+
+# import numpy as np
+import torch
+
+#from scipy.spatial.transform import Rotation
+from rotations2 import TorchRotation as Rotation
+
+#from pegasus.simulator.logic.rotations import rot_ENU_to_NED, rot_FLU_to_FRD
+from rotations2 import rot_ENU_to_NED, rot_FLU_to_FRD
+
 
 
 class State:
@@ -24,30 +31,33 @@ class State:
         - linear acceleration - An array with [x_ddot, y_ddot, z_ddot] with the acceleration of the vehicle expressed in the inertial frame according to an ENU convention.
     """
 
-    def __init__(self):
+    def __init__(self, device):
         """
         Initialize the State object
         """
 
+        # Define the same device that is running the simulation
+        self.device = device
+
         # The position [x,y,z] of the vehicle's body frame relative to the inertial frame, expressed in the inertial frame
-        self.position = np.array([0.0, 0.0, 0.0])
+        self.position = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The attitude (orientation) of the vehicle's body frame relative to the inertial frame of reference,
         # expressed in the inertial frame. This quaternion should follow the convention [qx, qy, qz, qw], such that "no rotation"
         # equates to the quaternion=[0, 0, 0, 1]
-        self.attitude = np.array([0.0, 0.0, 0.0, 1.0])
+        self.attitude = torch.tensor([0.0, 0.0, 0.0, 1.0], dtype=torch.float32, device=self.device)
 
         # The linear velocity [u,v,w] of the vehicle's body frame expressed in the body frame of reference
-        self.linear_body_velocity = np.array([0.0, 0.0, 0.0])
+        self.linear_body_velocity = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The linear velocity [x_dot, y_dot, z_dot] of the vehicle's body frame expressed in the inertial frame of reference
-        self.linear_velocity = np.array([0.0, 0.0, 0.0])
+        self.linear_velocity = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The angular velocity [wx, wy, wz] of the vehicle's body frame relative to the inertial frame, expressed in the body frame
-        self.angular_velocity = np.array([0.0, 0.0, 0.0])
+        self.angular_velocity = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The linear acceleration [ax, ay, az] of the vehicle's body frame relative to the inertial frame, expressed in the inertial frame
-        self.linear_acceleration = np.array([0.0, 0.0, 0.0])
+        self.linear_acceleration = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
     def get_position_ned(self):
         """
@@ -57,7 +67,8 @@ class State:
         Returns:
             np.ndarray: A numpy array with the [x,y,z] of the vehicle expressed in the inertial frame according to an NED convention.
         """
-        return rot_ENU_to_NED.apply(self.position)
+        return rot_ENU_to_NED(device=self.device, dtype=torch.float32).apply(self.position)
+
 
     def get_attitude_ned_frd(self):
         """
@@ -67,7 +78,8 @@ class State:
         Returns:
             np.ndarray: A numpy array with the quaternion [qx, qy, qz, qw] that encodes the attitude of the vehicle's FRD body frame, relative to an NED inertial frame, expressed in the NED inertial frame.
         """
-        attitude_frd_ned = rot_ENU_to_NED * Rotation.from_quat(self.attitude) * rot_FLU_to_FRD
+        attitude_frd_ned = rot_ENU_to_NED(device=self.device, dtype=torch.float32) * Rotation.from_quat(self.attitude) * rot_FLU_to_FRD(device=self.device, dtype=torch.float32)
+
         return attitude_frd_ned.as_quat()
 
     def get_linear_body_velocity_ned_frd(self):
@@ -83,7 +95,7 @@ class State:
         linear_acc_body_flu = Rotation.from_quat(self.attitude).inv().apply(self.linear_acceleration)
 
         # Convert the linear acceleration in the body frame expressed in FLU convention to the FRD convention
-        return rot_FLU_to_FRD.apply(linear_acc_body_flu)
+        return rot_FLU_to_FRD(device=self.device, dtype=torch.float32).apply(linear_acc_body_flu)
 
     def get_linear_velocity_ned(self):
         """
@@ -95,6 +107,7 @@ class State:
             np.ndarray: A numpy array with [vx,vy,vz] that defines the velocity of the vehicle expressed in the inertial frame according to a NED convention.
         """
         return rot_ENU_to_NED.apply(self.linear_velocity)
+        
 
     def get_angular_velocity_frd(self):
         """

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/state.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/state.py
@@ -11,11 +11,9 @@ __all__ = ["State"]
 import torch
 
 #from scipy.spatial.transform import Rotation
-from rotations2 import TorchRotation as Rotation
+import pytorch3d.transforms as transforms
 
-#from pegasus.simulator.logic.rotations import rot_ENU_to_NED, rot_FLU_to_FRD
-from rotations2 import rot_ENU_to_NED, rot_FLU_to_FRD
-
+from pegasus.simulator.logic.rotations import rot_ENU_to_NED, rot_FLU_to_FRD
 
 
 class State:
@@ -23,11 +21,11 @@ class State:
     Stores the state of a given vehicle.
     
     Note:
-        - position - A numpy array with the [x,y,z] of the vehicle expressed in the inertial frame according to an ENU convention.
-        - orientation - A numpy array with the quaternion [qx, qy, qz, qw] that encodes the attitude of the vehicle's FLU body frame, relative to an ENU inertial frame, expressed in the ENU inertial frame.
-        - linear_velocity - A numpy array with [vx,vy,vz] that defines the velocity of the vehicle expressed in the inertial frame according to an ENU convention.
-        - linear_body_velocity - A numpy array with [u,v,w] that defines the velocity of the vehicle expressed in the FLU body frame.
-        - angular_velocity - A numpy array with [p,q,r] with the angular velocity of the vehicle's FLU body frame, relative to an ENU inertial frame, expressed in the FLU body frame.
+        - position - A torch tensor with the [x,y,z] of the vehicle expressed in the inertial frame according to an ENU convention.
+        - orientation - A torch tensor with the quaternion [qw, qx, qy, qz] that encodes the attitude of the vehicle's FLU body frame, relative to an ENU inertial frame, expressed in the ENU inertial frame.
+        - linear_velocity - A torch tensor with [vx,vy,vz] that defines the velocity of the vehicle expressed in the inertial frame according to an ENU convention.
+        - linear_body_velocity - A torch tensor with [u,v,w] that defines the velocity of the vehicle expressed in the FLU body frame.
+        - angular_velocity - A torch tensor with [p,q,r] with the angular velocity of the vehicle's FLU body frame, relative to an ENU inertial frame, expressed in the FLU body frame.
         - linear acceleration - An array with [x_ddot, y_ddot, z_ddot] with the acceleration of the vehicle expressed in the inertial frame according to an ENU convention.
     """
 
@@ -43,9 +41,9 @@ class State:
         self.position = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The attitude (orientation) of the vehicle's body frame relative to the inertial frame of reference,
-        # expressed in the inertial frame. This quaternion should follow the convention [qx, qy, qz, qw], such that "no rotation"
-        # equates to the quaternion=[0, 0, 0, 1]
-        self.attitude = torch.tensor([0.0, 0.0, 0.0, 1.0], dtype=torch.float32, device=self.device)
+        # expressed in the inertial frame. This quaternion should follow the convention [qw, qx, qy, qz], such that "no rotation"
+        # equates to the quaternion=[1, 0, 0, 0]
+        self.attitude = torch.tensor([1.0, 0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
 
         # The linear velocity [u,v,w] of the vehicle's body frame expressed in the body frame of reference
         self.linear_body_velocity = torch.tensor([0.0, 0.0, 0.0], dtype=torch.float32, device=self.device)
@@ -65,9 +63,9 @@ class State:
         to the NED convention used by PX4 and other onboard flight controllers
 
         Returns:
-            np.ndarray: A numpy array with the [x,y,z] of the vehicle expressed in the inertial frame according to an NED convention.
+            np.ndarray: A torch tensor with the [x,y,z] of the vehicle expressed in the inertial frame according to an NED convention.
         """
-        return rot_ENU_to_NED(device=self.device, dtype=torch.float32).apply(self.position)
+        return rot_ENU_to_NED(device=self.device, dtype=torch.float32) @ self.position
 
 
     def get_attitude_ned_frd(self):
@@ -76,11 +74,12 @@ class State:
         attitude of the vehicle it to the NED-FRD convention used by PX4 and other onboard flight controllers
 
         Returns:
-            np.ndarray: A numpy array with the quaternion [qx, qy, qz, qw] that encodes the attitude of the vehicle's FRD body frame, relative to an NED inertial frame, expressed in the NED inertial frame.
+            np.ndarray: A torch tensor with the quaternion [qw, qx, qy, qz] that encodes the attitude of the vehicle's FRD body frame, relative to an NED inertial frame, expressed in the NED inertial frame.
         """
-        attitude_frd_ned = rot_ENU_to_NED(device=self.device, dtype=torch.float32) * Rotation.from_quat(self.attitude) * rot_FLU_to_FRD(device=self.device, dtype=torch.float32)
 
-        return attitude_frd_ned.as_quat()
+        attitude_frd_ned = rot_ENU_to_NED(device=self.device, dtype=torch.float32) @ transforms.quaternion_to_matrix(self.attitude) @ rot_FLU_to_FRD(device=self.device, dtype=torch.float32)
+
+        return transforms.matrix_to_quaternion(attitude_frd_ned)
 
     def get_linear_body_velocity_ned_frd(self):
         """
@@ -88,14 +87,14 @@ class State:
         linear body velocity of the vehicle it to the NED-FRD convention used by PX4 and other onboard flight controllers
 
         Returns:
-            np.ndarray: A numpy array with [u,v,w] that defines the velocity of the vehicle expressed in the FRD body frame.
+            np.ndarray: A torch tensor with [u,v,w] that defines the velocity of the vehicle expressed in the FRD body frame.
         """
 
         # Get the linear acceleration in FLU convention
-        linear_acc_body_flu = Rotation.from_quat(self.attitude).inv().apply(self.linear_acceleration)
+        linear_acc_body_flu = transforms.quaternion_to_matrix(self.attitude).T @ self.linear_acceleration
 
         # Convert the linear acceleration in the body frame expressed in FLU convention to the FRD convention
-        return rot_FLU_to_FRD(device=self.device, dtype=torch.float32).apply(linear_acc_body_flu)
+        return rot_FLU_to_FRD(device=self.device, dtype=torch.float32) @ linear_acc_body_flu
 
     def get_linear_velocity_ned(self):
         """
@@ -104,9 +103,9 @@ class State:
         controllers
 
         Returns:
-            np.ndarray: A numpy array with [vx,vy,vz] that defines the velocity of the vehicle expressed in the inertial frame according to a NED convention.
+            np.ndarray: A torch tensor with [vx,vy,vz] that defines the velocity of the vehicle expressed in the inertial frame according to a NED convention.
         """
-        return rot_ENU_to_NED.apply(self.linear_velocity)
+        return rot_ENU_to_NED(device=self.device, dtype=torch.float32) @ self.linear_velocity
         
 
     def get_angular_velocity_frd(self):
@@ -116,9 +115,9 @@ class State:
         controllers
 
         Returns:
-            np.ndarray: A numpy array with [p,q,r] with the angular velocity of the vehicle's FRD body frame, relative to an NED inertial frame, expressed in the FRD body frame.
+            np.ndarray: A torch tensor with [p,q,r] with the angular velocity of the vehicle's FRD body frame, relative to an NED inertial frame, expressed in the FRD body frame.
         """
-        return rot_FLU_to_FRD.apply(self.angular_velocity)
+        return rot_FLU_to_FRD(device=self.device, dtype=torch.float32) @ self.angular_velocity
 
     def get_linear_acceleration_ned(self):
         """
@@ -129,4 +128,4 @@ class State:
         Returns:
             np.ndarray: An array with [x_ddot, y_ddot, z_ddot] with the acceleration of the vehicle expressed in the inertial frame according to an NED convention.
         """
-        return rot_ENU_to_NED.apply(self.linear_acceleration)
+        return rot_ENU_to_NED(device=self.device, dtype=torch.float32) @ self.linear_acceleration

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/thrusters/quadratic_thrust_curve.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/thrusters/quadratic_thrust_curve.py
@@ -4,14 +4,15 @@
 | Descriptio: File that implements a quadratic thrust curve for rotors
 | License: BSD-3-Clause. Copyright (c) 2023, Marcelo Jacinto. All rights reserved.
 """
-import numpy as np
+#import numpy as np
+import torch
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.thrusters.thrust_curve import ThrustCurve
 
 class QuadraticThrustCurve(ThrustCurve):
     """Class that implements the dynamics of rotors that can be described by a quadratic thrust curve
     """
-    def __init__(self, config={}):
+    def __init__(self, config={}, device="cpu"):
         """_summary_
 
         Args:
@@ -28,40 +29,42 @@ class QuadraticThrustCurve(ThrustCurve):
             >>>  "max_rotor_velocity": [1100, 1100, 1100, 1100],          # rad/s
             >>> }
         """
+        # Set device
+        self.device = device
 
         # Get the total number of rotors to simulate
         self._num_rotors = config.get("num_rotors", 4)
 
         # The rotor constant used for computing the total thrust produced by the rotor: T = rotor_constant * omega^2
-        self._rotor_constant = config.get("rotor_constant", [8.54858e-6, 8.54858e-6, 8.54858e-6, 8.54858e-6])
+        self._rotor_constant = torch.tensor(config.get("rotor_constant", [8.54858e-6, 8.54858e-6, 8.54858e-6, 8.54858e-6]), dtype=torch.float32, device=self.device)
         assert len(self._rotor_constant) == self._num_rotors
 
         # The rotor constant used for computing the total torque generated about the vehicle Z-axis
-        self._rolling_moment_coefficient = config.get("rolling_moment_coefficient", [1e-6, 1e-6, 1e-6, 1e-6])
+        self._rolling_moment_coefficient = torch.tensor(config.get("rolling_moment_coefficient", [1e-6, 1e-6, 1e-6, 1e-6]), dtype=torch.float32, device=self.device)
         assert len(self._rolling_moment_coefficient) == self._num_rotors
 
         # Save the rotor direction of rotation
-        self._rot_dir = config.get("rot_dir", [-1, -1, 1, 1])
+        self._rot_dir = torch.tensor(config.get("rot_dir", [-1, -1, 1, 1]), dtype=torch.int32, device=self.device)
         assert len(self._rot_dir) == self._num_rotors
 
         # Values for the minimum and maximum rotor velocity in rad/s
-        self.min_rotor_velocity = config.get("min_rotor_velocity", [0, 0, 0, 0])
+        self.min_rotor_velocity = torch.tensor(config.get("min_rotor_velocity", [0, 0, 0, 0]), dtype=torch.float32, device=self.device)
         assert len(self.min_rotor_velocity) == self._num_rotors
 
-        self.max_rotor_velocity = config.get("max_rotor_velocity", [1100, 1100, 1100, 1100])
+        self.max_rotor_velocity = torch.tensor(config.get("max_rotor_velocity", [1100, 1100, 1100, 1100]), dtype=torch.float32, device=self.device)
         assert len(self.max_rotor_velocity) == self._num_rotors
 
         # The actual speed references to apply to the vehicle rotor joints
-        self._input_reference = [0.0 for i in range(self._num_rotors)]
-
+        self._input_reference = torch.zeros(self._num_rotors, dtype=torch.float32, device=self.device)
+        
         # The actual velocity that each rotor is spinning at
-        self._velocity = [0.0 for i in range(self._num_rotors)]
+        self._velocity = torch.zeros(self._num_rotors, dtype=torch.float32, device=self.device)
 
         # The actual force that each rotor is generating
-        self._force = [0.0 for i in range(self._num_rotors)]
+        self._force = torch.zeros(self._num_rotors, dtype=torch.float32, device=self.device)
 
         # The actual rolling moment that is generated on the body frame of the vehicle
-        self._rolling_moment = 0.0
+        self._rolling_moment = torch.tensor(0.0, dtype=torch.float32, device=self.device)
 
     def set_input_reference(self, input_reference):
         """
@@ -69,7 +72,7 @@ class QuadraticThrustCurve(ThrustCurve):
         """
 
         # The target angular velocity of the rotor
-        self._input_reference = input_reference
+        self._input_reference = torch.as_tensor(input_reference, dtype=torch.float32, device=self.device)
 
     def update(self, state: State, dt: float):
         """
@@ -82,22 +85,22 @@ class QuadraticThrustCurve(ThrustCurve):
             dt (float): The time elapsed between the previous and current function calls (s).
         """
 
-        rolling_moment = 0.0
+        rolling_moment = torch.tensor(0.0, dtype=torch.float32, device=self.device)
 
         # Compute the actual force to apply to the rotors and the rolling moment contribution
         for i in range(self._num_rotors):
 
             # Set the actual velocity that each rotor is spinning at (instanenous model - no delay introduced)
             # Only apply clipping of the input reference
-            self._velocity[i] = np.maximum(
-                self.min_rotor_velocity[i], np.minimum(self._input_reference[i], self.max_rotor_velocity[i])
+            self._velocity[i] = torch.maximum(
+                self.min_rotor_velocity[i], torch.minimum(self._input_reference[i], self.max_rotor_velocity[i])
             )
 
             # Set the force using a quadratic thrust curve
-            self._force[i] = self._rotor_constant[i] * np.power(self._velocity[i], 2)
+            self._force[i] = self._rotor_constant[i] * torch.pow(self._velocity[i], 2)
 
             # Compute the rolling moment coefficient
-            rolling_moment += self._rolling_moment_coefficient[i] * np.power(self._velocity[i], 2.0) * self._rot_dir[i]
+            rolling_moment += self._rolling_moment_coefficient[i] * torch.pow(self._velocity[i], 2.0) * self._rot_dir[i]
 
         # Update the rolling moment variable
         self._rolling_moment = rolling_moment

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/thrusters/thrust_curve.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/thrusters/thrust_curve.py
@@ -54,7 +54,7 @@ class ThrustCurve:
         """The total rolling moment being generated on the body frame of the vehicle by the rotating propellers
 
         Returns:
-            float: The total rolling moment to apply to the vehicle body frame (Torque about the Z-axis) in Nm
+            torch.Tensor: The total rolling moment to apply to the vehicle body frame (Torque about the Z-axis) in Nm
         """
         pass
 

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
@@ -5,7 +5,8 @@
 | Description: Definition of the Multirotor class which is used as the base for all the multirotor vehicles.
 """
 
-import numpy as np
+#import numpy as np
+import torch
 
 from omni.isaac.dynamic_control import _dynamic_control
 
@@ -20,6 +21,10 @@ from pegasus.simulator.logic.dynamics import LinearDrag
 from pegasus.simulator.logic.thrusters import QuadraticThrustCurve
 from pegasus.simulator.logic.sensors import Barometer, IMU, Magnetometer, GPS
 
+# Extension APIs
+from pegasus.simulator.logic.interface.pegasus_interface import PegasusInterface
+
+
 class MultirotorConfig:
     """
     A data class that is used for configuring a Multirotor
@@ -29,6 +34,8 @@ class MultirotorConfig:
         """
         Initialization of the MultirotorConfig class
         """
+        # Define the same device that is running the simulation
+        device = PegasusInterface()._world_settings["device"]
 
         # Stage prefix of the vehicle when spawning in the world
         self.stage_prefix = "quadrotor"
@@ -37,11 +44,11 @@ class MultirotorConfig:
         self.usd_file = ""
 
         # The default thrust curve for a quadrotor and dynamics relating to drag
-        self.thrust_curve = QuadraticThrustCurve()
+        self.thrust_curve = QuadraticThrustCurve(device = device)
         self.drag = LinearDrag([0.50, 0.30, 0.0])
 
         # The default sensors for a quadrotor
-        self.sensors = [Barometer(), IMU(), Magnetometer(), GPS()]
+        self.sensors = [Barometer(device=device), IMU(device=device), Magnetometer(device=device), GPS(device=device)]
 
         # The default graphical sensors for a quadrotor
         self.graphical_sensors = []
@@ -66,7 +73,7 @@ class Multirotor(Vehicle):
         vehicle_id: int = 0,
         # Spawning pose of the vehicle
         init_pos=[0.0, 0.0, 0.07],
-        init_orientation=[0.0, 0.0, 0.0, 1.0],
+        init_orientation=[1.0, 0.0, 0.0, 0.0],
         config=MultirotorConfig(),
     ):
         """Initializes the multirotor object
@@ -76,7 +83,7 @@ class Multirotor(Vehicle):
             usd_file (str): The USD file that describes the looks and shape of the vehicle. Defaults to "".
             vehicle_id (int): The id to be used for the vehicle. Defaults to 0.
             init_pos (list): The initial position of the vehicle in the inertial frame (in ENU convention). Defaults to [0.0, 0.0, 0.07].
-            init_orientation (list): The initial orientation of the vehicle in quaternion [qx, qy, qz, qw]. Defaults to [0.0, 0.0, 0.0, 1.0].
+            init_orientation (list): The initial orientation of the vehicle in quaternion [qw, qx, qy, qz]. Defaults to [1.0, 0.0, 0.0, 0.0].
             config (MultirotorConfig, optional): Defaults to MultirotorConfig().
         """
 
@@ -112,7 +119,7 @@ class Multirotor(Vehicle):
         if len(self._backends) != 0:
             desired_rotor_velocities = self._backends[0].input_reference()
         else:
-            desired_rotor_velocities = [0.0 for i in range(self._thrusters._num_rotors)]
+            desired_rotor_velocities = torch.zeros(self._thrusters._num_rotors, dtype=torch.float32, device=self.device)
 
         # Input the desired rotor velocities in the thruster model
         self._thrusters.set_input_reference(desired_rotor_velocities)
@@ -122,7 +129,6 @@ class Multirotor(Vehicle):
 
         # Apply force to each rotor
         for i in range(4):
-
             # Apply the force in Z on the rotor frame
             self.apply_force([0.0, 0.0, forces_z[i]], body_part="/rotor" + str(i))
 
@@ -138,6 +144,7 @@ class Multirotor(Vehicle):
 
         # Call the update methods in all backends
         for backend in self._backends:
+            backend._vehicle = self
             backend.update(dt)
 
     def handle_propeller_visual(self, rotor_number, force: float, articulation):
@@ -164,7 +171,7 @@ class Multirotor(Vehicle):
         else:
             self.get_dc_interface().set_dof_velocity(joint, 0)
 
-    def force_and_torques_to_velocities(self, force: float, torque: np.ndarray):
+    def force_and_torques_to_velocities(self, force: float, torque: torch.Tensor):        
         """
         Auxiliar method used to get the target angular velocities for each rotor, given the total desired thrust [N] and
         torque [Nm] to be applied in the multirotor's body frame.
@@ -190,23 +197,23 @@ class Multirotor(Vehicle):
         relative_poses = self.get_dc_interface().get_relative_body_poses(rb, rotors)
 
         # Define the alocation matrix
-        aloc_matrix = np.zeros((4, self._thrusters._num_rotors))
+        aloc_matrix = torch.zeros((4, self._thrusters._num_rotors), dtype=torch.float32, device=self.device)
         
         # Define the first line of the matrix (T [N])
-        aloc_matrix[0, :] = np.array(self._thrusters._rotor_constant)                                           
+        aloc_matrix[0, :] = torch.tensor(self._thrusters._rotor_constant, dtype=torch.float32, device=self.device)
 
         # Define the second and third lines of the matrix (\tau_x [Nm] and \tau_y [Nm])
-        aloc_matrix[1, :] = np.array([relative_poses[i].p[1] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
-        aloc_matrix[2, :] = np.array([-relative_poses[i].p[0] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
+        aloc_matrix[1, :] = torch.tensor([relative_poses[i].p[1] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)], dtype=torch.float32, device=self.device)
+        aloc_matrix[2, :] = torch.tensor([-relative_poses[i].p[0] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)], dtype=torch.float32, device=self.device)
 
         # Define the forth line of the matrix (\tau_z [Nm])
-        aloc_matrix[3, :] = np.array([self._thrusters._rolling_moment_coefficient[i] * self._thrusters._rot_dir[i] for i in range(self._thrusters._num_rotors)])
+        aloc_matrix[3, :] = torch.tensor([self._thrusters._rolling_moment_coefficient[i] * self._thrusters._rot_dir[i] for i in range(self._thrusters._num_rotors)], dtype=torch.float32, device=self.device)
 
         # Compute the inverse allocation matrix, so that we can get the angular velocities (squared) from the total thrust and torques
-        aloc_inv = np.linalg.pinv(aloc_matrix)
+        aloc_inv = torch.linalg.pinv(aloc_matrix)
 
         # Compute the target angular velocities (squared)
-        squared_ang_vel = aloc_inv @ np.array([force, torque[0], torque[1], torque[2]])
+        squared_ang_vel = aloc_inv @ torch.tensor([force, torque[0], torque[1], torque[2]], dtype=torch.float32, device=self.device)
 
         # Making sure that there is no negative value on the target squared angular velocities
         squared_ang_vel[squared_ang_vel < 0] = 0.0
@@ -214,15 +221,15 @@ class Multirotor(Vehicle):
         # ------------------------------------------------------------------------------------------------
         # Saturate the inputs while preserving their relation to each other, by performing a normalization
         # ------------------------------------------------------------------------------------------------
-        max_thrust_vel_squared = np.power(self._thrusters.max_rotor_velocity[0], 2)
-        max_val = np.max(squared_ang_vel)
+        max_thrust_vel_squared = torch.pow(self._thrusters.max_rotor_velocity[0], 2)
+        max_val = torch.max(squared_ang_vel)
 
         if max_val >= max_thrust_vel_squared:
-            normalize = np.maximum(max_val / max_thrust_vel_squared, 1.0)
+            normalize = torch.clamp(max_val / max_thrust_vel_squared, min=1.0)
 
             squared_ang_vel = squared_ang_vel / normalize
 
         # Compute the angular velocities for each rotor in [rad/s]
-        ang_vel = np.sqrt(squared_ang_vel)
+        ang_vel = torch.sqrt(squared_ang_vel)
 
         return ang_vel

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
@@ -200,7 +200,7 @@ class Multirotor(Vehicle):
         aloc_matrix = torch.zeros((4, self._thrusters._num_rotors), dtype=torch.float32, device=self.device)
         
         # Define the first line of the matrix (T [N])
-        aloc_matrix[0, :] = torch.tensor(self._thrusters._rotor_constant, dtype=torch.float32, device=self.device)
+        aloc_matrix[0, :] = self._thrusters._rotor_constant
 
         # Define the second and third lines of the matrix (\tau_x [Nm] and \tau_y [Nm])
         aloc_matrix[1, :] = torch.tensor([relative_poses[i].p[1] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)], dtype=torch.float32, device=self.device)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -6,8 +6,12 @@
 """
 
 # Numerical computations
-import numpy as np
-from scipy.spatial.transform import Rotation
+
+# import numpy as np
+import torch
+
+#from scipy.spatial.transform import Rotation
+import pytorch3d.transforms as transforms
 
 # Low level APIs
 import carb
@@ -66,6 +70,9 @@ class Vehicle(Robot):
             init_orientation (list): The initial orientation of the vehicle in quaternion [qx, qy, qz, qw]. Defaults to [0.0, 0.0, 0.0, 1.0].
         """
 
+        # Define the same device that is running the simulation
+        self.device = PegasusInterface()._world_settings["device"]
+
         # Get the current world at which we want to spawn the vehicle
         self._world = PegasusInterface().world
         self._current_stage = self._world.stage
@@ -105,7 +112,7 @@ class Vehicle(Robot):
         VehicleManager.get_vehicle_manager().add_vehicle(self._stage_prefix, self)
 
         # Variable that will hold the current state of the vehicle
-        self._state = State()
+        self._state = State(self.device)
 
         # Add a callback to the physics engine to update the current state of the system
         self._world.add_physics_callback(self._stage_prefix + "/state", self.update_state)
@@ -126,7 +133,12 @@ class Vehicle(Robot):
         self._sensors = sensors
         
         for sensor in self._sensors:
-            sensor.initialize(self, PegasusInterface().latitude, PegasusInterface().longitude, PegasusInterface().altitude)
+            sensor.initialize(
+                self, 
+                torch.tensor(PegasusInterface().latitude, dtype=torch.float32, device=self.device), 
+                torch.tensor(PegasusInterface().longitude, dtype=torch.float32, device=self.device), 
+                torch.tensor(PegasusInterface().altitude, dtype=torch.float32, device=self.device)
+            )
 
         # Add callbacks to the physics engine to update each sensor at every timestep
         # and let the sensor decide depending on its internal update rate whether to generate new data
@@ -308,27 +320,26 @@ class Vehicle(Robot):
 
         # Get the linear acceleration of the body relative to the inertial frame, expressed in the inertial frame
         # Note: we must do this approximation, since the Isaac sim does not output the acceleration of the rigid body directly
-        linear_acceleration = (np.array(linear_vel) - self._state.linear_velocity) / dt
+        linear_acceleration = (torch.tensor([linear_vel.x, linear_vel.y, linear_vel.z], dtype=torch.float32, device=self.device) - self._state.linear_velocity) / dt
 
         # Update the state variable X = [x,y,z]
-        self._state.position = np.array(pose.p)
+        self._state.position = torch.tensor([pose.p.x, pose.p.y, pose.p.z], dtype=torch.float32, device=self.device)
 
-        # Get the quaternion according in the [qx,qy,qz,qw] standard
-        self._state.attitude = np.array(
-            [rotation_quat_img[0], rotation_quat_img[1], rotation_quat_img[2], rotation_quat_real]
+        # Get the quaternion according in the [qw,qx,qy,qz] standard
+        self._state.attitude = torch.tensor(
+            [rotation_quat_real, rotation_quat_img[0], rotation_quat_img[1], rotation_quat_img[2]], dtype=torch.float32, device=self.device
         )
 
         # Express the velocity of the vehicle in the inertial frame X_dot = [x_dot, y_dot, z_dot]
-        self._state.linear_velocity = np.array(linear_vel)
+        self._state.linear_velocity = torch.tensor([linear_vel.x, linear_vel.y, linear_vel.z], dtype=torch.float32, device=self.device)
 
         # The linear velocity V =[u,v,w] of the vehicle's body frame expressed in the body frame of reference
         # Note that: x_dot = Rot * V
-        self._state.linear_body_velocity = (
-            Rotation.from_quat(self._state.attitude).inv().apply(self._state.linear_velocity)
-        )
+        self._state.linear_body_velocity = transforms.quaternion_apply(transforms.quaternion_invert(self._state.attitude), self._state.linear_velocity)
 
         # omega = [p,q,r]
-        self._state.angular_velocity = Rotation.from_quat(self._state.attitude).inv().apply(np.array(ang_vel))
+        ang_vel_tensor = torch.tensor([ang_vel.x, ang_vel.y, ang_vel.z], dtype=torch.float32, device=self.device)
+        self._state.angular_velocity = transforms.quaternion_apply(transforms.quaternion_invert(self._state.attitude), ang_vel_tensor)
 
         # The acceleration of the vehicle expressed in the inertial frame X_ddot = [x_ddot, y_ddot, z_ddot]
         self._state.linear_acceleration = linear_acceleration
@@ -373,6 +384,7 @@ class Vehicle(Robot):
             # If some data was updated and we have a mavlink backend or ros backend (or other), then just update it
             if sensor_data is not None:
                 for backend in self._backends:
+                    backend._vehicle = self
                     backend.update_sensor(sensor.sensor_type, sensor_data)
 
     def update_graphical_sensors(self, event):
@@ -392,6 +404,7 @@ class Vehicle(Robot):
             # If some data was updated and we have a ros backend (or other), then just update it
             if sensor_data is not None:
                 for backend in self._backends:
+                    backend._vehicle = self
                     backend.update_graphical_sensor(sensor.sensor_type, sensor_data)
 
     def update_sim_state(self, dt: float):
@@ -403,6 +416,7 @@ class Vehicle(Robot):
             dt (float): The time elapsed between the previous and current function calls (s).
         """
         for backend in self._backends:
+            backend._vehicle = self
             backend.update_state(self._state)
 
     def get_dc_interface(self):


### PR DESCRIPTION
The vehicle, sensor, and related classes were modified so that most of the logic can be executed in CUDA.

Operations previously implemented with SciPy were adapted to use the PyTorch3D library. The default quaternion order was changed to `[w, x, y, z]` instead of having the real component as the last element as before.

The classes now expect tensors and return tensors in most of their methods. The device is selected depending on where the simulation is running.

The current interaction API using Articulation is only valid when the simulation runs on the CPU.

Future work will involve migrating this interaction API to RigidPrim, as demonstrated in the new test `test_iris_rigid_prim.py`.