### PR TITLE
fix: replace invalid list exclude with regex in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 22.12.0
     hooks:
       - id: black
-        exclude: ["geo_mag_utils.py"]
+        exclude: ^geo_mag_utils\.py$
         args: ["--line-length", "120"]
   - repo: https://github.com/pycqa/flake8
     rev: 6.0.0


### PR DESCRIPTION
While working on a separate pull request, I set up `pre-commit` in a virtual environment in order to run it locally. Running `pre-commit run --all-files` immediately resulted in the following error:
```
An error has occurred: InvalidConfigError: 
==> File .pre-commit-config.yaml
==> At Config()
==> At key: repos
==> At Repository(repo='https://github.com/python/black')
==> At key: hooks
==> At Hook(id='black')
==> At key: exclude
=====> Expected string got list
```
While the list defined under the exclude key is valid YAML, it appears that the pre-commit schema expects a single regex string instead.

This PR replaces the YAML list with an equivalent regex that targets the intended file exclusion.

---

**Separate but related**:
A fresh run of `pre-commit run --all-files` results in ~109 modified files. I have intentionally not included those here to keep this PR focused and easy to review 😅