### PR TITLE
fix: ensure both world and physics context are initialized when spawning vehicle from UI …

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
@@ -207,7 +207,14 @@ class UIDelegate:
             # Check if we already have a physics environment activated. If not, then activate it
             # and only after spawn the vehicle. This is to avoid trying to spawn a vehicle without a physics
             # environment setup. This way we can even spawn a vehicle in an empty world and it won't care
-            if hasattr(self._pegasus_sim.world, "_physics_context") == False:
+
+            # Ensure the world is initialized first
+            if self._pegasus_sim.world is None:
+                self._pegasus_sim.initialize_world()
+            
+            # Ensure physics context is initialized and ready
+            if (self._pegasus_sim.world._physics_context is None or 
+                self._pegasus_sim.world._physics_context._physx_interface is None):
                 await self._pegasus_sim.world.initialize_simulation_context_async()
 
             # Check if a vehicle is selected in the drop-down menu


### PR DESCRIPTION
**Short version**
If loading a scene outside of Pegasus Simulator's GUI, we can end in a state where there's no reference to the world or physics context, blocking the user from spawning vehicles. This PR changes the safety check in `async_load_vehicle()` so that if we are in that scenario, we correct it and can spawn vehicles.

**Long version**
I'm experimenting with using Pegasus Simulator together with the Cesium for Omniverse extension. This comes with several challenges on its own, one namely being how stages/scenes should be handled.

What I was hoping to do was to utilize the existing functionality in Pegasus Simulator for loading scenes, which adds the environment as a referenced `.usd` file, which is good! So make a separate file, set up a Cesium environment there, add a path in the parameters, and load as needed. 

The problem: Cesium is (currently) a bit opinionated on how a stage should be structured in Isaac Sim: 
- Whenever a new stage is defined or loaded, Cesium adds a number of utility prims that handle settings, server connection, georeference etc. 
- These are always added to the stage root. *Not* as a child of the default prim.
- Since they're not under the default prim, they are not loaded when the `.usd` is referenced.
- Attempting to parent the prims under the default prim caused the extension to *create new copies*, which then leaves the environment in a broken state with overlapping copies of terrain, which may or may not be textured.

So this is a lose-lose situation. I have yet to find a good way to set things up by script, but it is possible to do manually through the Isaac Sim GUI, tedious as it is. 

This is where the PR comes in. To make this slightly less tedious, I attempted to do the following:
- Set up the environment with Cesium, save it for reuse.
- With the Pegasus Simulator interface, set up coordinates as usual, but *do not use any of the buttons to load or clear the scene*. 
- Skip straight to loading the vehicle, as `async_load_vehicle` states it should check if we have a activated physics environment. 

I then hit two problems that blocked this from working:
- `self._pegasus_sim.world` was still `None` at this point, since none of the scene-loading code had been called. 
- Even after making a check if there is a world, and calling `initialize_world()` if not, `self._pegasus_sim.world._physics_context` could either be `None` or not properly initialized.

This PR addresses exactly that, so that if one attempts to spawn a vehicle without having used the load or clear scene buttons, it will still succeed.