### PR TITLE
fix: bind rotor index in ros2 subscriber callbacks

### DIFF
--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
@@ -165,7 +165,7 @@ class ROS2Backend(Backend):
             # The current setup as it is.... its a pain!!!!
             self.rotor_subs = []
             for i in range(self._num_rotors):
-                self.rotor_subs.append(self.node.create_subscription(Float64, self._namespace + str(self._id) + "/control/rotor" + str(i) + "/ref", lambda x: self.rotor_callback(x, i),10))
+                self.rotor_subs.append(self.node.create_subscription(Float64, self._namespace + str(self._id) + "/control/rotor" + str(i) + "/ref", lambda x, idx=i: self.rotor_callback(x, idx),10))
 
 
     def send_static_transforms(self):


### PR DESCRIPTION
Fixes #140.

In `ROS2Backend.initialize_subscribers`, the per-rotor subscription callback is created inside a `for i in range(self._num_rotors)` loop with `lambda x: self.rotor_callback(x, i)`. Due to Python's late-binding of closure variables, every lambda ends up referencing the same `i`, which by the time any callback fires is the loop's final value (`self._num_rotors - 1`). The result is that all `/drone{N}/control/rotorX/ref` topics write into the last rotor's slot in `input_ref`, so only the last rotor responds to commands regardless of which topic is published to.

The fix is the standard default-argument idiom to capture `i` at lambda-definition time:

```python
lambda x, idx=i: self.rotor_callback(x, idx)
```

Patch is one line, matches the workaround the issue author identified. No other lambdas in this file have the same loop-closure pattern.