### PR TITLE
feat: migrate Pegasus to Isaac Sim 6.0

### DIFF
--- a/examples/0_template_app.py
+++ b/examples/0_template_app.py
@@ -19,7 +19,11 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core import World
+import omni.usd
+from pxr import UsdGeom, UsdPhysics, Gf
+from isaacsim.core.simulation_manager import SimulationManager, SimulationEvent
+from isaacsim.core.rendering_manager import RenderingManager, RenderingEvent
+import isaacsim.core.experimental.utils.app as app_utils
 
 class Template:
     """
@@ -30,57 +34,60 @@ class Template:
         """
         Method that initializes the template App and is used to setup the simulation environment.
         """
-        
+
         # Acquire the timeline that will be used to start/stop the simulation
         self.timeline = omni.timeline.get_timeline_interface()
 
-        # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
-        # spawning asset primitives, etc.
-        self.world = World()
+        # Set up simulation with a default physics dt of 1/60 s
+        SimulationManager.set_physics_dt(1.0 / 60.0)
 
-        # Create a ground plane for the simulation
-        self.world.scene.add_default_ground_plane()
+        # Add a simple ground plane via USD physics (large flat cube with collision)
+        stage = omni.usd.get_context().get_stage()
+        ground = UsdGeom.Cube.Define(stage, "/World/groundPlane")
+        ground.GetSizeAttr().Set(150.0)
+        xform = UsdGeom.Xformable(ground.GetPrim())
+        xform.AddTranslateOp().Set(Gf.Vec3d(0.0, 0.0, -0.5))
+        xform.AddScaleOp().Set(Gf.Vec3d(1.0, 1.0, 0.01))
+        UsdPhysics.CollisionAPI.Apply(ground.GetPrim())
 
-        # Create an example physics callback
-        self.world.add_physics_callback('template_physics_callback', self.physics_callback)
+        # Register example physics callback
+        self._cb_physics = SimulationManager.register_callback(
+            self.physics_callback, SimulationEvent.PHYSICS_POST_STEP
+        )
 
-        # Create an example render callback
-        self.world.add_render_callback('template_render_callback', self.render_callback)
+        # Register example render callback
+        self._cb_render = RenderingManager.register_callback(
+            RenderingEvent.NEW_FRAME, callback=self.render_callback
+        )
 
-        # Create an example timeline callback
-        self.world.add_timeline_callback('template_timeline_callback', self.timeline_callback)
+        # Register simulation stopped callback (replaces the old timeline callback)
+        self._cb_stop = SimulationManager.register_callback(
+            self._on_sim_stopped, SimulationEvent.SIMULATION_STOPPED
+        )
 
-        # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
-
-        # Auxiliar variable for the timeline callback example
+        # Auxiliar variable for the stop callback example
         self.stop_sim = False
 
-    def physics_callback(self, dt: float):
+    def physics_callback(self, dt: float, context=None):
         """An example physics callback. It will get invoked every physics step.
 
         Args:
             dt (float): The time difference between the previous and current function call, in seconds.
+            context: Physics step context (unused).
         """
         carb.log_info("This is a physics callback. It is called every " + str(dt) + " seconds!")
 
-    def render_callback(self, data):
+    def render_callback(self, event):
         """An example render callback. It will get invoked for every rendered frame.
 
         Args:
-            data: Rendering data.
+            event: Rendering event from RenderingManager.
         """
         carb.log_info("This is a render callback. It is called every frame!")
 
-    def timeline_callback(self, timeline_event):
-        """An example timeline callback. It will get invoked every time a timeline event occurs. In this example,
-        we will check if the event is for a 'simulation stop'. If so, we will attempt to close the app
-
-        Args:
-            timeline_event: A timeline event
-        """
-        if self.world.is_stopped():
-            self.stop_sim = True
+    def _on_sim_stopped(self, *args):
+        """Invoked when the simulation stops."""
+        self.stop_sim = True
 
     def run(self):
         """
@@ -94,10 +101,13 @@ class Template:
         while simulation_app.is_running() and not self.stop_sim:
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
-        
+            simulation_app.update()
+
         # Cleanup and stop
         carb.log_warn("Template Simulation App is closing.")
+        SimulationManager.deregister_callback(self._cb_physics)
+        SimulationManager.deregister_callback(self._cb_stop)
+        RenderingManager.deregister_callback(self._cb_render)
         self.timeline.stop()
         simulation_app.close()
 

--- a/examples/10_graphs.py
+++ b/examples/10_graphs.py
@@ -20,9 +20,9 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
-from omni.isaac.core.objects import DynamicCuboid
+import omni.usd
 import numpy as np
+from pxr import UsdGeom, UsdPhysics, Gf
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -52,23 +52,20 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics,
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
 
-        
-        cube_2 = self.world.scene.add(
-            DynamicCuboid(
-                prim_path="/new_cube_2",
-                name="cube_1",
-                position=np.array([-3.0, 0, 2.0]),
-                scale=np.array([1.0, 1.0, 1.0]),
-                size=1.0,
-                color=np.array([255, 0, 0]),
-            )
-        )
+        # Add a dynamic rigid body cube using USD physics API
+        _stage = omni.usd.get_context().get_stage()
+        cube_geom = UsdGeom.Cube.Define(_stage, "/new_cube_2")
+        cube_geom.GetSizeAttr().Set(1.0)
+        xform = UsdGeom.Xformable(cube_geom.GetPrim())
+        xform.AddTranslateOp().Set(Gf.Vec3d(-3.0, 0.0, 2.0))
+        UsdPhysics.RigidBodyAPI.Apply(cube_geom.GetPrim())
+        UsdPhysics.CollisionAPI.Apply(cube_geom.GetPrim())
+        UsdPhysics.MassAPI.Apply(cube_geom.GetPrim()).GetMassAttr().Set(1.0)
 
         # Create the vehicle
         # Try to spawn the selected robot in the world to the specified namespace
@@ -96,8 +93,6 @@ class PegasusApp:
             config=config_multirotor,
         )
 
-        # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -113,7 +108,7 @@ class PegasusApp:
         # The "infinite" loop
         while simulation_app.is_running() and not self.stop_sim:
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
 
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/11_ardupilot_multi_vehicle.py
+++ b/examples/11_ardupilot_multi_vehicle.py
@@ -19,7 +19,6 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -49,8 +48,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
@@ -60,7 +58,6 @@ class PegasusApp:
             self.vehicle_factory(i, gap_x_axis=1.0)
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -118,7 +115,7 @@ class PegasusApp:
         while simulation_app.is_running() and not self.stop_sim:
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/1_px4_single_vehicle.py
+++ b/examples/1_px4_single_vehicle.py
@@ -19,7 +19,6 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -49,8 +48,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Box Room"])
@@ -77,7 +75,6 @@ class PegasusApp:
         )
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -94,7 +91,7 @@ class PegasusApp:
         while simulation_app.is_running() and not self.stop_sim:
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/2_px4_multi_vehicle.py
+++ b/examples/2_px4_multi_vehicle.py
@@ -19,7 +19,6 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -49,8 +48,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
@@ -61,7 +59,6 @@ class PegasusApp:
         
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -106,7 +103,7 @@ class PegasusApp:
         while simulation_app.is_running() and not self.stop_sim:
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/3_ros2_single_vehicle.py
+++ b/examples/3_ros2_single_vehicle.py
@@ -20,9 +20,8 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
 
-from isaacsim.core.utils.extensions import enable_extension
+from isaacsim.core.experimental.utils.app import enable_extension
 enable_extension("isaacsim.ros2.bridge")
 
 # Import the Pegasus API for simulating drones
@@ -53,8 +52,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
@@ -83,7 +81,6 @@ class PegasusApp:
         )
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -100,7 +97,7 @@ class PegasusApp:
         while simulation_app.is_running() and not self.stop_sim:
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/4_python_single_vehicle.py
+++ b/examples/4_python_single_vehicle.py
@@ -20,7 +20,6 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -57,8 +56,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
@@ -86,7 +84,6 @@ class PegasusApp:
         )
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
     def run(self):
         """
@@ -100,7 +97,7 @@ class PegasusApp:
         while simulation_app.is_running():
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/5_python_multi_vehicle.py
+++ b/examples/5_python_multi_vehicle.py
@@ -20,10 +20,8 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
-
-# Used for adding extra lights to the environment
-import isaacsim.core.utils.prims as prim_utils
+import omni.usd
+from pxr import Sdf, Gf
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS
@@ -64,23 +62,18 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Add a custom light with a high-definition HDR surround environment of an exhibition hall,
         # instead of the typical ground plane
-        prim_utils.create_prim(
-            "/World/Light/DomeLight",
-            "DomeLight",
-            position=np.array([1.0, 1.0, 1.0]),
-            attributes={
-                "inputs:intensity": 5e3,
-                "inputs:color": (1.0, 1.0, 1.0),
-                "inputs:texture:file": "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/NVIDIA/Assets/Skies/Indoor/ZetoCGcom_ExhibitionHall_Interior1.hdr"
-                # Alternative sky: https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/NVIDIA/Assets/Skies/Cloudy/abandoned_parking_4k.hdr
-            }
-
-            
+        # Add a dome light using USD API
+        _stage = omni.usd.get_context().get_stage()
+        _stage.DefinePrim("/World/Light", "Xform")
+        dome_prim = _stage.DefinePrim("/World/Light/DomeLight", "DomeLight")
+        dome_prim.CreateAttribute("inputs:intensity", Sdf.ValueTypeNames.Float).Set(5e3)
+        dome_prim.CreateAttribute("inputs:color", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(1.0, 1.0, 1.0))
+        dome_prim.CreateAttribute("inputs:texture:file", Sdf.ValueTypeNames.Asset).Set(
+            "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/NVIDIA/Assets/Skies/Indoor/ZetoCGcom_ExhibitionHall_Interior1.hdr"
         )
 
         # Get the current directory used to read trajectories and save results
@@ -139,7 +132,6 @@ class PegasusApp:
         point_list_2 = [(trajectory2[i,1], trajectory2[i,2], trajectory2[i,3]) for i in range(num_samples2)]
         draw.draw_lines_spline(point_list_2, (255/255, 0, 0, 1), 5, False)
 
-        self.world.reset()
 
     def run(self):
         """
@@ -153,7 +145,7 @@ class PegasusApp:
         while simulation_app.is_running():
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/6_paper_results.py
+++ b/examples/6_paper_results.py
@@ -21,13 +21,8 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
-
-# Used for adding extra lights to the environment
-import isaacsim.core.utils.prims as prim_utils
-
-import omni.kit.commands
-from pxr import Sdf
+import omni.usd
+from pxr import Sdf, UsdLux, Gf
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS
@@ -68,18 +63,16 @@ class PegasusApp:
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics, 
         # spawning asset primitives, etc.
         self.pg._world_settings = {"physics_dt": 1.0 / 500.0, "stage_units_in_meters": 1.0, "rendering_dt": 1.0 / 60.0}
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
-        prim_utils.create_prim(
-            "/World/Light/DomeLight",
-            "DomeLight",
-            position=np.array([1.0, 1.0, 1.0]),
-            attributes={
-                "inputs:intensity": 5e3,
-                "inputs:color": (1.0, 1.0, 1.0),
-                "inputs:texture:file": "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/NVIDIA/Assets/Skies/Indoor/ZetoCGcom_ExhibitionHall_Interior1.hdr"
-            }
+        # Add a dome light to the scene using USD API
+        _stage = omni.usd.get_context().get_stage()
+        _stage.DefinePrim("/World/Light", "Xform")
+        dome_prim = _stage.DefinePrim("/World/Light/DomeLight", "DomeLight")
+        dome_prim.CreateAttribute("inputs:intensity", Sdf.ValueTypeNames.Float).Set(5e3)
+        dome_prim.CreateAttribute("inputs:color", Sdf.ValueTypeNames.Color3f).Set(Gf.Vec3f(1.0, 1.0, 1.0))
+        dome_prim.CreateAttribute("inputs:texture:file", Sdf.ValueTypeNames.Asset).Set(
+            "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/4.5/NVIDIA/Assets/Skies/Indoor/ZetoCGcom_ExhibitionHall_Interior1.hdr"
         )
 
         # Get the current directory used to read trajectories and save results
@@ -139,8 +132,6 @@ class PegasusApp:
         point_list_2 = [(trajectory2[i][0], trajectory2[i][1], trajectory2[i][2]) for i in range(num_samples)]
         draw.draw_lines_spline(point_list_2, (255/255, 0, 0, 1), 5, False)
 
-        # Reset the world
-        self.world.reset()
 
     def run(self):
         """
@@ -154,7 +145,7 @@ class PegasusApp:
         while simulation_app.is_running():
 
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
         
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/8_camera_vehicle.py
+++ b/examples/8_camera_vehicle.py
@@ -20,10 +20,9 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
-
-from omni.isaac.core.objects import DynamicCuboid
+import omni.usd
 import numpy as np
+from pxr import UsdGeom, UsdPhysics, Gf
 
 # Import the Pegasus API for simulating drones
 from pegasus.simulator.params import ROBOTS, SIMULATION_ENVIRONMENTS
@@ -55,22 +54,20 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics,
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
 
-        cube_2 = self.world.scene.add(
-            DynamicCuboid(
-                prim_path="/new_cube_2",
-                name="cube_1",
-                position=np.array([-3.0, 0, 2.0]),
-                scale=np.array([1.0, 1.0, 1.0]),
-                size=1.0,
-                color=np.array([255, 0, 0]),
-            )
-        )
+        # Add a dynamic rigid body cube using USD physics API
+        _stage = omni.usd.get_context().get_stage()
+        cube_geom = UsdGeom.Cube.Define(_stage, "/new_cube_2")
+        cube_geom.GetSizeAttr().Set(1.0)
+        xform = UsdGeom.Xformable(cube_geom.GetPrim())
+        xform.AddTranslateOp().Set(Gf.Vec3d(-3.0, 0.0, 2.0))
+        UsdPhysics.RigidBodyAPI.Apply(cube_geom.GetPrim())
+        UsdPhysics.CollisionAPI.Apply(cube_geom.GetPrim())
+        UsdPhysics.MassAPI.Apply(cube_geom.GetPrim()).GetMassAttr().Set(1.0)
 
         # Create the vehicle
         # Try to spawn the selected robot in the world to the specified namespace
@@ -103,8 +100,6 @@ class PegasusApp:
             config=config_multirotor,
         )
 
-        # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -120,7 +115,7 @@ class PegasusApp:
         # The "infinite" loop
         while simulation_app.is_running() and not self.stop_sim:
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
 
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/8_camera_vehicle.py
+++ b/examples/8_camera_vehicle.py
@@ -76,7 +76,6 @@ class PegasusApp:
         mavlink_config = PX4MavlinkBackendConfig({
             "vehicle_id": 0,
             "px4_autolaunch": True,
-            "px4_dir": "/home/marcelo/PX4-Autopilot"
         })
         config_multirotor.backends = [
             PX4MavlinkBackend(mavlink_config), 

--- a/examples/9_people.py
+++ b/examples/9_people.py
@@ -20,8 +20,7 @@ simulation_app = SimulationApp({"headless": False})
 # The actual script should start here
 # -----------------------------------
 import omni.timeline
-from omni.isaac.core.world import World
-from isaacsim.core.utils.extensions import enable_extension
+from isaacsim.core.experimental.utils.app import enable_extension
 
 # Enable/disable ROS bridge extensions to keep only ROS2 Bridge
 enable_extension("isaacsim.ros2.bridge")
@@ -96,8 +95,7 @@ class PegasusApp:
 
         # Acquire the World, .i.e, the singleton that controls that is a one stop shop for setting up physics,
         # spawning asset primitives, etc.
-        self.pg._world = World(**self.pg._world_settings)
-        self.world = self.pg.world
+        self.pg.initialize_world()
 
         # Launch one of the worlds provided by NVIDIA
         #self.pg.load_environment(SIMULATION_ENVIRONMENTS["Curved Gridroom"])
@@ -150,7 +148,6 @@ class PegasusApp:
         self.pg.set_viewport_camera([5.0, 9.0, 6.5], [0.0, 0.0, 0.0])
 
         # Reset the simulation environment so that all articulations (aka robots) are initialized
-        self.world.reset()
 
         # Auxiliar variable for the timeline callback example
         self.stop_sim = False
@@ -166,7 +163,7 @@ class PegasusApp:
         # The "infinite" loop
         while simulation_app.is_running() and not self.stop_sim:
             # Update the UI of the app and perform the physics step
-            self.world.step(render=True)
+            simulation_app.update()
 
         # Cleanup and stop
         carb.log_warn("PegasusApp Simulation App is closing.")

--- a/examples/9_people.py
+++ b/examples/9_people.py
@@ -119,7 +119,6 @@ class PegasusApp:
         mavlink_config = PX4MavlinkBackendConfig({
             "vehicle_id": 0,
             "px4_autolaunch": True,
-            "px4_dir": "/home/marcelo/PX4-Autopilot"     # TODO -> Change this line to the path where you have the PX4-Autopilot code downloaded (this is an example on how you can set your own path for PX4)
         })
 
         config_multirotor.backends = [

--- a/extensions/pegasus.simulator/config/extension.toml
+++ b/extensions/pegasus.simulator/config/extension.toml
@@ -44,6 +44,7 @@ icon = "data/icon.png"
 "isaacsim.core.experimental.prims" = {}
 "isaacsim.core.experimental.utils" = {}
 "isaacsim.replicator.agent.core" = {}
+"omni.anim.graph.core" = {}
 
 # Main python module this extension provides, it will be publicly available as "import pegasus.simulator".
 [[python.module]]

--- a/extensions/pegasus.simulator/config/extension.toml
+++ b/extensions/pegasus.simulator/config/extension.toml
@@ -1,6 +1,6 @@
 [package]
 # Semantic Versioning is used: https://semver.org/
-version = "5.1.0"
+version = "6.0.0"
 
 # Lists people or organizations that are considered the "authors" of the package.
 authors = ["Marcelo Jacinto"]
@@ -37,9 +37,12 @@ icon = "data/icon.png"
 "omni.ui" = {}
 "omni.usd" = {}
 "omni.kit.uiapp" = {}
-"omni.isaac.core" = {}
 "omni.ui.scene" = {}
 "omni.kit.capture.viewport" = {}
+"isaacsim.core.simulation_manager" = {}
+"isaacsim.core.rendering_manager" = {}
+"isaacsim.core.experimental.prims" = {}
+"isaacsim.core.experimental.utils" = {}
 "isaacsim.replicator.agent.core" = {}
 
 # Main python module this extension provides, it will be publicly available as "import pegasus.simulator".

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/__init__.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/__init__.py
@@ -10,6 +10,7 @@ from .ardupilot_mavlink_backend import ArduPilotMavlinkBackend, ArduPilotMavlink
 # Check if the ROS2 package is installed
 try:
     from .ros2_backend import ROS2Backend
-except:
+except Exception as e:
     import carb
-    carb.log_warn("ROS2 package not installed. ROS2Backend will not be available")
+    import traceback
+    carb.log_warn(f"ROS2Backend not available: {e}\n{traceback.format_exc()}")

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
@@ -7,7 +7,7 @@
 
 # Make sure the ROS2 extension is enabled
 import carb
-from isaacsim.core.utils.extensions import enable_extension
+from isaacsim.core.experimental.utils.app import enable_extension
 enable_extension("isaacsim.ros2.bridge")
 
 # ROS2 imports

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/backends/ros2_backend.py
@@ -33,7 +33,7 @@ from pegasus.simulator.logic.backends.backend import Backend
 import omni
 import omni.graph.core as og
 import omni.replicator.core as rep
-from isaacsim.ros2.bridge import read_camera_info
+from isaacsim.ros2.core.impl.camera_info_utils import read_camera_info
 
 
 class ROS2Backend(Backend):

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/lidar.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/lidar.py
@@ -8,11 +8,11 @@ __all__ = ["Lidar"]
 
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.graphical_sensors import GraphicalSensor
-from pegasus.simulator.logic.interface.pegasus_interface import PegasusInterface
 
 # Imports the python bindings to interact with lidar sensor
+import omni.usd
 import omni.kit.commands
-from pxr import Gf, UsdGeom  
+from pxr import Gf, UsdGeom
 from omni.usd import get_stage_next_free_path
 
 # Auxiliary scipy and numpy modules
@@ -55,7 +55,7 @@ class Lidar(GraphicalSensor):
         super().initialize(vehicle)
         
         # Get the complete stage prefix for the lidar
-        self._stage_prim_path = get_stage_next_free_path(PegasusInterface().world.stage, self._vehicle.prim_path + "/body/" + self._lidar_name, False)
+        self._stage_prim_path = get_stage_next_free_path(omni.usd.get_context().get_stage(), self._vehicle.prim_path + "/body/" + self._lidar_name, False)
 
         # Get the camera name that was actually created (and update the camera name)
         self._lidar_name = self._stage_prim_path.rpartition("/")[-1]

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/monocular_camera.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphical_sensors/monocular_camera.py
@@ -8,8 +8,8 @@ __all__ = ["MonocularCamera"]
 
 from pegasus.simulator.logic.state import State
 from pegasus.simulator.logic.graphical_sensors import GraphicalSensor
-from pegasus.simulator.logic.interface.pegasus_interface import PegasusInterface
 
+import omni.usd
 from isaacsim.sensors.camera.camera import Camera
 from omni.usd import get_stage_next_free_path
 
@@ -92,7 +92,7 @@ class MonocularCamera(GraphicalSensor):
         super().initialize(vehicle)
 
         # Get the complete stage prefix for the camera
-        self._stage_prim_path = get_stage_next_free_path(PegasusInterface().world.stage, self._vehicle.prim_path + "/body/" + self._camera_name, False)
+        self._stage_prim_path = get_stage_next_free_path(omni.usd.get_context().get_stage(), self._vehicle.prim_path + "/body/" + self._camera_name, False)
 
         # Get the camera name that was actually created (and update the camera name)
         self._camera_name = self._stage_prim_path.rpartition("/")[-1]

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_camera_graph.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/graphs/ros2_camera_graph.py
@@ -6,11 +6,9 @@ __all__ = ["ROS2CameraGraph"]
 
 import carb
 
-from isaacsim.core.utils import stage
+import omni.usd
 import omni.graph.core as og
-from isaacsim.core.utils.prims import is_prim_path_valid
-from isaacsim.core.utils.prims import set_targets
-from omni.isaac.sensor import Camera
+from pxr import Sdf
 
 from pegasus.simulator.logic.graphs import Graph
 from pegasus.simulator.logic.vehicles import Vehicle
@@ -78,20 +76,9 @@ class ROS2CameraGraph(Graph):
         if self._camera_prim_path[0] != '/':
             self._camera_prim_path = f"{vehicle.prim_path}/{self._camera_prim_path}"
 
-        # Create the camera object attached to the vehicle
-        self.camera = Camera(
-            prim_path=self._camera_prim_path,
-            position=np.array([0.30, 0.0, 0.0]),
-            frequency=30.0,
-            resolution=self._resolution,
-            orientation=Rotation.from_euler("ZYX", [0.0, 0.0, 0.0], degrees=True).as_quat()
-        )
-
-        # Initialize the camera sensor
-        self.camera.initialize()
-
-        # Create camera prism
-        if not is_prim_path_valid(self._camera_prim_path):
+        # Verify the camera prim exists in the stage
+        _stage = omni.usd.get_context().get_stage()
+        if not _stage.GetPrimAtPath(self._camera_prim_path).IsValid():
             carb.log_error(f"Cannot create ROS2 Camera graph, the camera prim path \"{self._camera_prim_path}\" is not valid")
             return
 
@@ -208,12 +195,9 @@ class ROS2CameraGraph(Graph):
              graph_config
         )
 
-        # Connect camera to the graphs
-        set_targets(
-            prim=stage.get_current_stage().GetPrimAtPath(f"{graph_path}/set_camera"),
-            attribute="inputs:cameraPrim",
-            target_prim_paths=[self._camera_prim_path]
-        )
+        # Connect camera to the graph using USD relationship API
+        set_camera_prim = omni.usd.get_context().get_stage().GetPrimAtPath(f"{graph_path}/set_camera")
+        set_camera_prim.GetRelationship("inputs:cameraPrim").SetTargets([Sdf.Path(self._camera_prim_path)])
 
         # Run the ROS Camera graph once to generate ROS image publishers in SDGPipeline
         og.Controller.evaluate_sync(graph)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/interface/pegasus_interface.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/interface/pegasus_interface.py
@@ -17,9 +17,10 @@ from threading import Lock
 # NVidia API imports
 import carb
 import omni.kit.app
-from isaacsim.core.api.world import World
-from isaacsim.core.utils.stage import clear_stage, create_new_stage_async, update_stage_async, create_new_stage
-from isaacsim.core.utils.viewports import set_camera_view
+import omni.usd
+from isaacsim.core.simulation_manager import SimulationManager
+import isaacsim.core.experimental.utils.app as app_utils
+import isaacsim.core.experimental.utils.stage as stage_utils
 import isaacsim.storage.native as nucleus
 
 # Pegasus Simulator internal API
@@ -30,7 +31,7 @@ from pegasus.simulator.logic.vehicle_manager import VehicleManager
 class PegasusInterface:
     """
     PegasusInterface is a singleton class (there is only one object instance at any given time) that will be used
-    to 
+    to
     """
 
     # The object instance of the Vehicle Manager
@@ -58,8 +59,7 @@ class PegasusInterface:
 
         # Initialize the world with the default simulation settings
         self._world_settings = DEFAULT_WORLD_SETTINGS
-        self._world = None
-        
+
         # Initialize the latitude, longitude and altitude of the simulated environment at the (0.0, 0.0, 0.0) coordinate
         # from the extension configuration file
         self._latitude, self._longitude, self._altitude = self._get_global_coordinates_from_config()
@@ -76,15 +76,6 @@ class PegasusInterface:
 
 
     @property
-    def world(self):
-        """The current isaacsim.core.api.world World instance
-
-        Returns:
-            isaacsim.core.api.world: The world instance
-        """
-        return self._world
-
-    @property
     def vehicle_manager(self):
         """The instance of the VehicleManager.
 
@@ -92,7 +83,7 @@ class PegasusInterface:
             VehicleManager: The current instance of the VehicleManager.
         """
         return self._vehicle_manager
-    
+
     @property
     def latitude(self):
         """The latitude of the origin of the simulated world in degrees.
@@ -101,7 +92,7 @@ class PegasusInterface:
             float: The latitude of the origin of the simulated world in degrees.
         """
         return self._latitude
-    
+
     @property
     def longitude(self):
         """The longitude of the origin of the simulated world in degrees.
@@ -110,7 +101,7 @@ class PegasusInterface:
             float: The longitude of the origin of the simulated world in degrees.
         """
         return self._longitude
-    
+
     @property
     def altitude(self):
         """The altitude of the origin of the simulated world in meters.
@@ -119,7 +110,7 @@ class PegasusInterface:
             float: The latitude of the origin of the simulated world in meters.
         """
         return self._altitude
-    
+
     @property
     def px4_path(self):
         """A string with the installation directory for PX4 (if it was setup). Otherwise it is None.
@@ -128,7 +119,7 @@ class PegasusInterface:
             str: A string with the installation directory for PX4 (if it was setup). Otherwise it is None.
         """
         return self._px4_path
-    
+
     @property
     def ardupilot_path(self):
         """A string with the installation directory for ArduPilot (if it was setup). Otherwise it is None.
@@ -137,7 +128,7 @@ class PegasusInterface:
             str: A string with the installation directory for ArduPilot (if it was setup). Otherwise it is None.
         """
         return self._ardupilot_path
-    
+
     @property
     def px4_default_airframe(self):
         """A string with the PX4 default airframe (if it was setup). Otherwise it is None.
@@ -146,7 +137,7 @@ class PegasusInterface:
             str: A string with the PX4 default airframe (if it was setup). Otherwise it is None.
         """
         return self._px4_default_airframe
-    
+
     @property
     def ardupilot_default_airframe(self):
         """A string with the ArduPilot default airframe (if it was setup). Otherwise it is None.
@@ -155,7 +146,7 @@ class PegasusInterface:
             str: A string with the ArduPilot default airframe (if it was setup). Otherwise it is None.
         """
         return self._ardupilot_default_airframe
-    
+
     def set_global_coordinates(self, latitude=None, longitude=None, altitude=None):
         """Method that can be used to set the latitude, longitude and altitude of the simulation world at the origin.
 
@@ -177,16 +168,15 @@ class PegasusInterface:
         carb.log_warn("New global coordinates set to: " + str(self._latitude) + ", " + str(self._longitude) + ", " + str(self._altitude))
 
     def initialize_world(self):
-        """Method that initializes the world object
-        """
-        self._world = World(**self._world_settings)
-        #asyncio.ensure_future(self._world.initialize_simulation_context_async())
+        """Apply simulation settings (physics dt) via SimulationManager."""
+        physics_dt = self._world_settings.get("physics_dt", 1.0 / 250.0)
+        SimulationManager.set_physics_dt(physics_dt)
 
     def get_vehicle(self, stage_prefix: str):
         """Method that returns the vehicle object given its 'stage_prefix', i.e., the name the vehicle was spawned with in the simulator.
 
         Args:
-            stage_prefix (str): The name the vehicle will present in the simulator when spawned. 
+            stage_prefix (str): The name the vehicle will present in the simulator when spawned.
 
         Returns:
             Vehicle: Returns a vehicle object that was spawned with the given 'stage_prefix'
@@ -230,16 +220,7 @@ class PegasusInterface:
         """
 
         # If the physics simulation was running, stop it first
-        if self._world is not None:
-            self._world.stop()
-
-        # Clear the world
-        if self._world is not None:
-            self._world.clear_all_callbacks()
-            self._world.clear()
-
-        # Clear the stage
-        clear_stage()
+        app_utils.stop()
 
         # Remove all the robots that were spawned
         self._vehicle_manager.remove_all_vehicles()
@@ -247,11 +228,8 @@ class PegasusInterface:
         # Call python's garbage collection
         gc.collect()
 
-        # Re-initialize the world
-        self._world = World(**self._world_settings)
-
-        # Re-initialize the physics context
-        asyncio.ensure_future(self._world.initialize_simulation_context_async())
+        # Create a new stage to clear the scene
+        asyncio.ensure_future(stage_utils.create_new_stage_async())
         carb.log_info("Current scene and its vehicles has been deleted")
 
     async def load_environment_async(self, usd_path: str, backend: str = 'px4', force_clear: bool=False):
@@ -259,24 +237,16 @@ class PegasusInterface:
 
         Args:
             usd_path (str): The path where the USD file describing the world is located.
-            force_clear (bool): Whether to perform a clear before loading the asset. Defaults to False. 
+            force_clear (bool): Whether to perform a clear before loading the asset. Defaults to False.
             It should be set to True only if the method is invoked from an App (GUI mode).
         """
 
         carb.log_warn("Loading a new environment into the simulator. Please wait...")
 
-        # Reset and pause the world simulation (only if force_clear is true)
-        # This is done to maximize the support between running in GUI as extension vs App
-        if force_clear == True:
-
-            # Create a new stage and initialize (or re-initialized) the world
-            await create_new_stage_async()
-            self._world = World(**self._world_settings)
-            await self._world.initialize_simulation_context_async()
-            self._world = World.instance()
-
-            await self._world.reset_async()
-            await self._world.stop_async()
+        if force_clear:
+            await stage_utils.create_new_stage_async()
+            physics_dt = self._world_settings.get("physics_dt", 1.0 / 250.0)
+            SimulationManager.set_physics_dt(physics_dt)
 
         # Load the USD asset that will be used for the environment
         try:
@@ -288,7 +258,7 @@ class PegasusInterface:
 
     def load_environment(self, usd_path: str, force_clear: bool=False):
         """Method that loads a given world (specified in the usd_path) into the simulator. If invoked from a python app,
-        this method should have force_clear=False, as the world reset and stop are performed asynchronously by this method, 
+        this method should have force_clear=False, as the world reset and stop are performed asynchronously by this method,
         and when we are operating in App mode, we want everything to run in sync.
 
         Args:
@@ -323,15 +293,16 @@ class PegasusInterface:
 
         Args:
             usd_asset (str): The path where the USD file describing the world is located.
-            stage_prefix (str): The name the vehicle will present in the simulator when spawned. 
+            stage_prefix (str): The name the vehicle will present in the simulator when spawned.
         """
+        stage = omni.usd.get_context().get_stage()
 
         # Try to check if there is already a prim with the same stage prefix in the stage
-        if self._world.stage.GetPrimAtPath(stage_prefix):
+        if stage.GetPrimAtPath(stage_prefix):
             raise Exception("A primitive already exists at the specified path")
 
         # Create the stage primitive and load the usd into it
-        prim = self._world.stage.DefinePrim(stage_prefix)
+        prim = stage.DefinePrim(stage_prefix)
         success = prim.GetReferences().AddReference(usd_asset)
 
         if not success:
@@ -344,8 +315,16 @@ class PegasusInterface:
             camera_position (list): A list with [X, Y, Z] coordinates of the camera in ENU inertial frame.
             camera_target (list): A list with [X, Y, Z] coordinates of the target that the camera should point to in the ENU inertial frame.
         """
-        # Set the camera view to a fixed value
-        set_camera_view(eye=camera_position, target=camera_target)
+        try:
+            from omni.kit.viewport.utility import get_active_viewport
+            from omni.kit.viewport.utility.camera_state import ViewportCameraState
+            viewport = get_active_viewport()
+            if viewport:
+                camera_state = ViewportCameraState(viewport)
+                camera_state.set_position_world(camera_position, True)
+                camera_state.set_target_world(camera_target, True)
+        except Exception as e:
+            carb.log_warn(f"Could not set viewport camera: {e}")
 
     def set_world_settings(self, physics_dt=None, stage_units_in_meters=None, rendering_dt=None, device=None):
         """
@@ -369,14 +348,14 @@ class PegasusInterface:
 
     def _get_px4_path_from_config(self):
         """
-        Method that reads the configured PX4 installation directory from the extension configuration file 
+        Method that reads the configured PX4 installation directory from the extension configuration file
 
         Returns:
             str: A string with the path to the px4 configuration directory or empty string ''
         """
 
         px4_dir = ""
-        
+
         # Open the configuration file. If it fails, just return the empty path
         try:
             with open(CONFIG_FILE, 'r') as f:
@@ -386,17 +365,17 @@ class PegasusInterface:
             carb.log_warn("Could not retrieve px4_dir from: " + str(CONFIG_FILE))
 
         return px4_dir
-    
+
     def _get_ardupilot_path_from_config(self):
         """
-        Method that reads the configured ArduPilot installation directory from the extension configuration file 
+        Method that reads the configured ArduPilot installation directory from the extension configuration file
 
         Returns:
             str: A string with the path to the ardupilot configuration directory or empty string ''
         """
 
         ardupilot_dir = ""
-        
+
         # Open the configuration file. If it fails, just return the empty path
         try:
             with open(CONFIG_FILE, 'r') as f:
@@ -406,16 +385,16 @@ class PegasusInterface:
             carb.log_warn("Could not retrieve ardupilot_dir from: " + str(CONFIG_FILE))
 
         return ardupilot_dir
-    
+
     def _get_px4_default_airframe_from_config(self):
         """
-        Method that reads the configured PX4 default airframe from the extension configuration file 
+        Method that reads the configured PX4 default airframe from the extension configuration file
 
         Returns:
             str: A string with the path to the PX4 default airframe or empty string ''
         """
         px4_default_airframe = ""
-        
+
         # Open the configuration file. If it fails, just return the empty path
         try:
             with open(CONFIG_FILE, 'r') as f:
@@ -425,16 +404,16 @@ class PegasusInterface:
             carb.log_warn("Could not retrieve px4_default_airframe from: " + str(CONFIG_FILE))
 
         return px4_default_airframe
-    
+
     def _get_ardupilot_default_airframe_from_config(self):
         """
-        Method that reads the configured Ardupilot default airframe from the extension configuration file 
+        Method that reads the configured Ardupilot default airframe from the extension configuration file
 
         Returns:
             str: A string with the path to the Ardupilot default airframe or empty string ''
         """
         ardupilot_default_airframe = ""
-        
+
         # Open the configuration file. If it fails, just return the empty path
         try:
             with open(CONFIG_FILE, 'r') as f:
@@ -461,7 +440,7 @@ class PegasusInterface:
         try:
             with open(CONFIG_FILE, 'r') as f:
                 data = yaml.safe_load(f)
-                
+
                 # Try to read the coordinates from the configuration file
                 global_coordinates = data.get("global_coordinates", {})
                 latitude = global_coordinates.get("latitude", 0.0)
@@ -478,7 +457,7 @@ class PegasusInterface:
         Args:
             absolute_path (str): The new path of the px4-autopilot installation directory
         """
-        
+
         # Save the new path for current use during this simulation
         self._px4_path = os.path.expanduser(path)
 
@@ -504,7 +483,7 @@ class PegasusInterface:
         Args:
             absolute_path (str): The new path of the ArduPilot installation directory
         """
-        
+
         # Save the new path for current use during this simulation
         self._ardupilot_path = os.path.expanduser(path)
 
@@ -530,7 +509,7 @@ class PegasusInterface:
         Args:
             absolute_path (str): The new px4 default airframe
         """
-        
+
         # Save the new path for current use during this simulation
         self._px4_default_airframe = airframe
 
@@ -556,7 +535,7 @@ class PegasusInterface:
         Args:
             airframe (str): The new ArduPilot default airframe
         """
-        
+
         # Save the new airframe for current use during this simulation
         self._ardupilot_default_airframe = airframe
 
@@ -578,13 +557,13 @@ class PegasusInterface:
 
     def set_default_global_coordinates(self):
         """
-        Method that sets the latitude, longitude and altitude from the pegasus interface to the 
+        Method that sets the latitude, longitude and altitude from the pegasus interface to the
         default global coordinates specified in the extension configuration file
         """
         self._latitude, self._longitude, self._altitude = self._get_global_coordinates_from_config()
 
     def set_new_default_global_coordinates(self, latitude: float=None, longitude: float=None, altitude: float=None):
-        
+
         # Set the current global coordinates to the new default global coordinates
         self.set_global_coordinates(latitude, longitude, altitude)
 
@@ -605,8 +584,8 @@ class PegasusInterface:
 
                 if altitude is not None:
                     data["global_coordinates"]["altitude"] = altitude
-                
-                # Save the updated configurations    
+
+                # Save the updated configurations
                 yaml.dump(data, f)
         except:
             carb.log_warn("Could not save the new global coordinates to: " + str(CONFIG_FILE))

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -5,6 +5,7 @@
 | Description: Definition of the Person class which is used as the base for spawning people in the simulation world.
 """
 
+import asyncio
 import numpy as np
 from scipy.spatial.transform import Rotation
 
@@ -15,6 +16,7 @@ from pxr import Sdf, Gf, UsdGeom
 # High level Isaac sim APIs
 import NavSchema
 import omni.client
+import omni.kit.app
 import omni.usd
 from omni.usd import get_stage_next_free_path
 from isaacsim.storage.native import get_assets_root_path
@@ -120,9 +122,11 @@ class Person:
         # Characters assets path:
         # https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/5.1/Isaac/People/Characters/
 
-        # Add the animation graph to the agent, such that it can move around
+        # Add the animation graph to the agent, such that it can move around.
+        # ApplyBehaviorAgentAPICommand triggers OmniGraph creation which segfaults when
+        # called synchronously before the first app update; schedule it async instead.
         self.character_graph = None
-        self.add_animation_graph_to_agent()
+        asyncio.ensure_future(self._setup_animation_graph_async())
 
         # Set the controller for the person if any and initialize it
         self._controller = controller
@@ -314,6 +318,12 @@ class Person:
             except Exception as e:
                 carb.log_error(f"Failed to load HumanMotionLibrary: {e}")
 
+
+    async def _setup_animation_graph_async(self):
+        # Wait one frame so the HumanMotionLibrary payload is fully resolved and
+        # OmniGraph is ready to accept new nodes (avoids segfault in standalone mode).
+        await omni.kit.app.get_app().next_update_async()
+        self.add_animation_graph_to_agent()
 
     def add_animation_graph_to_agent(self):
         # In Isaac Sim 6.0, ApplyBehaviorAgentAPICommand replaces AnimationGraphAPI + Biped_Setup.usd.

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -15,11 +15,12 @@ from pxr import Sdf
 # High level Isaac sim APIs
 import NavSchema
 import omni.client
-from isaacsim.core.utils import prims
+import omni.usd
 from omni.usd import get_stage_next_free_path
 from isaacsim.storage.native import get_assets_root_path
-
-from omni.isaac.core import SimulationContext
+import isaacsim.core.experimental.utils.app as app_utils
+import isaacsim.core.experimental.utils.stage as stage_utils
+from isaacsim.core.simulation_manager import SimulationManager, SimulationEvent
 
 # New imports from the replicator API
 import omni.anim.graph.core as ag
@@ -40,7 +41,7 @@ class Person:
     """
 
     # Get root assets path from setting, if not set, get the Isaac-Sim asset path
-    people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/5.1/Isaac/People/Characters/"
+    people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/"
     character_root_prim_path = PrimPaths.characters_parent_path()
 
     assets_root_path = None   
@@ -71,9 +72,8 @@ class Person:
             controller (PersonController): A controller to add some custom behaviour to the movement of the person. Defaults to None.
         """
 
-        # Get the current world at which we want to spawn the vehicle
-        self._world = PegasusInterface().world
-        self._current_stage = self._world.stage
+        # Get the current stage
+        self._current_stage = omni.usd.get_context().get_stage()
 
         # Variable that will hold the current state of the vehicle
         self._state = State()
@@ -119,18 +119,23 @@ class Person:
         if self._backend:
             self._backend.initialize(self)
 
-        # Add a callback to the physics engine to update the current state of the person
-        self._world.add_physics_callback(self._stage_prefix + "/state", self.update_state)
-
-        # Add the update method to the physics callback if the world was received
-        # so that we can apply the new references to be tracked by the person
-        self._world.add_physics_callback(self._stage_prefix + "/update", self.update)
+        # Register physics callbacks with SimulationManager
+        self._cb_state = SimulationManager.register_callback(self.update_state, SimulationEvent.PHYSICS_POST_STEP)
+        self._cb_update = SimulationManager.register_callback(self.update, SimulationEvent.PHYSICS_POST_STEP)
 
         # Set the flag that signals if the simulation is running or not
         self._sim_running = False
 
-        # Add a callback to start/stop of the simulation once the play/stop button is hit
-        self._world.add_timeline_callback(self._stage_prefix + "/start_stop_sim", self.sim_start_stop)
+        # Register simulation start/stop callbacks
+        self._cb_sim_start = SimulationManager.register_callback(self._on_sim_started, SimulationEvent.SIMULATION_STARTED)
+        self._cb_sim_stop = SimulationManager.register_callback(self._on_sim_stopped, SimulationEvent.SIMULATION_STOPPED)
+
+    def __del__(self):
+        for cb_id in (self._cb_state, self._cb_update, self._cb_sim_start, self._cb_sim_stop):
+            try:
+                SimulationManager.deregister_callback(cb_id)
+            except Exception:
+                pass
 
     @property
     def state(self):
@@ -141,20 +146,15 @@ class Person:
         """
         return self._state
     
-    def sim_start_stop(self, event):
-        """
-        Callback that is called every time there is a timeline event such as starting/stoping the simulation.
-
-        Args:
-            event: A timeline event generated from Isaac Sim, such as starting or stoping the simulation.
-        """
-
-        # If the start/stop button was pressed, then call the start and stop methods accordingly
-        if self._world.is_playing() and self._sim_running == False:
+    def _on_sim_started(self, *args):
+        """Callback invoked when the simulation starts."""
+        if not self._sim_running:
             self._sim_running = True
             self.start()
 
-        if self._world.is_stopped() and self._sim_running == True:
+    def _on_sim_stopped(self, *args):
+        """Callback invoked when the simulation stops."""
+        if self._sim_running:
             self._sim_running = False
             self.stop()
 
@@ -172,7 +172,7 @@ class Person:
         if self._controller:
             self._controller.stop()
 
-    def update(self, dt: float):
+    def update(self, dt: float, context=None):
         """
         Method that implements the logic to make the person move around in the simulation world and also play the animation
 
@@ -220,7 +220,7 @@ class Person:
         self._target_speed = walk_speed
 
 
-    def update_state(self, dt: float):
+    def update_state(self, dt: float, context=None):
         """
         Method that is called at every physics step to retrieve and update the current state of the person, i.e., get
         the current position, orientation, linear and angular velocities and acceleration of the person.
@@ -280,7 +280,11 @@ class Person:
 
         # If the base biped character is not present in the stage, spawn it
         if not self._current_stage.GetPrimAtPath(Person.character_root_prim_path + "/Biped_Setup"):
-            prim = prims.create_prim(Person.character_root_prim_path + "/Biped_Setup", "Xform", usd_path=Person.assets_root_path + "/Biped_Setup.usd")
+            stage_utils.add_reference_to_stage(
+                usd_path=Person.assets_root_path + "/Biped_Setup.usd",
+                path=Person.character_root_prim_path + "/Biped_Setup",
+            )
+            prim = self._current_stage.GetPrimAtPath(Person.character_root_prim_path + "/Biped_Setup")
             prim.GetAttribute("visibility").Set("invisible")
 
 

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -296,26 +296,38 @@ class Person:
         # Update the navigation mesh to include the character skeleton root prim
         omni.kit.commands.execute("ApplyNavMeshAPICommand", prim_path=stage_name, api=NavSchema.NavMeshExcludeAPI)
 
-        # If the base biped character is not present in the stage, spawn it
-        if not self._current_stage.GetPrimAtPath(Person.character_root_prim_path + "/Biped_Setup"):
-            stage_utils.add_reference_to_stage(
-                usd_path=Person.assets_root_path + "/Biped_Setup.usd",
-                path=Person.character_root_prim_path + "/Biped_Setup",
-            )
-            prim = self._current_stage.GetPrimAtPath(Person.character_root_prim_path + "/Biped_Setup")
-            prim.GetAttribute("visibility").Set("invisible")
+        # Load HumanMotionLibrary (replaces Biped_Setup.usd in Isaac Sim 6.0)
+        motion_library_prim_path = Person.character_root_prim_path + "/HumanMotionLibrary"
+        if not self._current_stage.GetPrimAtPath(motion_library_prim_path):
+            try:
+                root_path = get_assets_root_path()
+                motion_library_url = f"{root_path}/Isaac/People/MotionLibrary/HumanMotionLibrary.usd"
+                omni.kit.commands.execute(
+                    "CreatePayloadCommand",
+                    usd_context=omni.usd.get_context(),
+                    path_to=motion_library_prim_path,
+                    asset_path=motion_library_url,
+                    prim_path=None,
+                    instanceable=False,
+                    select_prim=False,
+                )
+            except Exception as e:
+                carb.log_error(f"Failed to load HumanMotionLibrary: {e}")
 
 
     def add_animation_graph_to_agent(self):
-
-        # Get the animation graph that we are going to add to the person
-        animation_graph = self._current_stage.GetPrimAtPath(Person.character_root_prim_path + "/Biped_Setup/CharacterAnimation/AnimationGraph")
-
-        # Remove the animation graph attribute if it exists
-        omni.kit.commands.execute("RemoveAnimationGraphAPICommand", paths=[Sdf.Path(self.character_skel_root.GetPrimPath())])
-
-        # Add the animation graph to the character
-        omni.kit.commands.execute("ApplyAnimationGraphAPICommand", paths=[Sdf.Path(self.character_skel_root.GetPrimPath())], animation_graph_path=Sdf.Path(animation_graph.GetPrimPath()))
+        # In Isaac Sim 6.0, ApplyBehaviorAgentAPICommand replaces AnimationGraphAPI + Biped_Setup.usd.
+        # Apply the BehaviorAgentAPI to the character's SkelRoot, pointing at the HumanMotionLibrary.
+        if self.character_skel_root is None:
+            carb.log_warn("No SkelRoot found for character — skipping BehaviorAgentAPI setup.")
+            return
+        motion_library_prim_path = Person.character_root_prim_path + "/HumanMotionLibrary"
+        omni.kit.commands.execute(
+            "ApplyBehaviorAgentAPICommand",
+            skelroot_prim_paths=[self.character_skel_root.GetPath()],
+            motion_library_prim_path=motion_library_prim_path,
+            motion_library_skeleton_rig="Human",
+        )
 
 
     @staticmethod

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -40,7 +40,7 @@ class Person:
     """
 
     # Get root assets path from setting, if not set, get the Isaac-Sim asset path
-    people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/"
+    people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters"
     # Default parent path for character prims (matches isaacsim.replicator.agent.core config default)
     character_root_prim_path = "/World/Characters"
 

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -50,8 +50,23 @@ class Person:
     # Resolved lazily on first Person instantiation (not at module import time)
     assets_root_path = None
 
+    @classmethod
+    def _ensure_assets_root_path(cls):
+        """Resolve assets_root_path on first call. Called from __init__ and static helpers."""
+        if cls.assets_root_path is not None:
+            return
+        if cls.people_asset_folder:
+            cls.assets_root_path = cls.people_asset_folder
+        else:
+            try:
+                root_path = get_assets_root_path()
+                if root_path:
+                    cls.assets_root_path = f"{root_path}/Isaac/People/Characters"
+            except Exception as e:
+                carb.log_error(f"Could not resolve Isaac Sim asset root path: {e}")
+
     def __init__(
-        self, 
+        self,
         stage_prefix: str,
         character_name: str = None,
         init_pos=[0.0, 0.0, 0.0],
@@ -72,17 +87,8 @@ class Person:
         # Get the current stage
         self._current_stage = omni.usd.get_context().get_stage()
 
-        # Resolve assets root path lazily (carb settings are available by the time __init__ runs)
-        if Person.assets_root_path is None:
-            if Person.people_asset_folder:
-                Person.assets_root_path = Person.people_asset_folder
-            else:
-                try:
-                    root_path = get_assets_root_path()
-                    if root_path:
-                        Person.assets_root_path = f"{root_path}/Isaac/People/Characters"
-                except Exception as e:
-                    carb.log_error(f"Could not resolve Isaac Sim asset root path: {e}")
+        # Ensure the assets root path is resolved before first use
+        Person._ensure_assets_root_path()
 
         # Variable that will hold the current state of the vehicle
         self._state = State()
@@ -341,6 +347,7 @@ class Person:
 
     @staticmethod
     def get_character_asset_list():
+        Person._ensure_assets_root_path()
         # List all files in characters directory
         result, folder_list = omni.client.list("{}/".format(Person.assets_root_path))
 

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -10,7 +10,7 @@ from scipy.spatial.transform import Rotation
 
 # Low level APIs
 import carb
-from pxr import Sdf
+from pxr import Sdf, Gf, UsdGeom
 
 # High level Isaac sim APIs
 import NavSchema
@@ -22,14 +22,10 @@ import isaacsim.core.experimental.utils.app as app_utils
 import isaacsim.core.experimental.utils.stage as stage_utils
 from isaacsim.core.simulation_manager import SimulationManager, SimulationEvent
 
-# New imports from the replicator API
 # omni.anim.graph.core is in extscache in Isaac Sim 6.0 and must be enabled before import
 from isaacsim.core.experimental.utils.app import enable_extension
 enable_extension("omni.anim.graph.core")
 import omni.anim.graph.core as ag
-import isaacsim.replicator.agent.core
-from isaacsim.replicator.agent.core.settings import PrimPaths
-from isaacsim.replicator.agent.core.stage_util import CharacterUtil
 
 # Extension APIs
 from pegasus.simulator.logic.state import State
@@ -45,7 +41,8 @@ class Person:
 
     # Get root assets path from setting, if not set, get the Isaac-Sim asset path
     people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters/"
-    character_root_prim_path = PrimPaths.characters_parent_path()
+    # Default parent path for character prims (matches isaacsim.replicator.agent.core config default)
+    character_root_prim_path = "/World/Characters"
 
     assets_root_path = None   
 
@@ -265,12 +262,15 @@ class Person:
 
     def spawn_agent(self, usd_file, stage_name, init_pos, init_yaw):
 
-        # Get the last name after the last slash in the stage name
-        # We only want the name of the character, not the full path
-        character_name = stage_name.split("/")[-1]
-
-        # Spawn the character in the stage using the NVIDIA replicar API (which is suprisingly similar to the original version I provided in this function in version 4.2.0)
-        CharacterUtil.load_character_usd_to_stage(usd_file, init_pos, init_yaw, character_name)
+        # CharacterUtil.load_character_usd_to_stage was removed in Isaac Sim 6.0.
+        # Replicate its behavior: add a USD reference at the stage path and set the initial xform.
+        stage_utils.add_reference_to_stage(usd_path=usd_file, path=stage_name)
+        prim = self._current_stage.GetPrimAtPath(stage_name)
+        xformable = UsdGeom.Xformable(prim)
+        xformable.ClearXformOpOrder()
+        xformable.AddTranslateOp().Set(Gf.Vec3f(float(init_pos[0]), float(init_pos[1]), float(init_pos[2])))
+        yaw_quat = Rotation.from_euler('z', init_yaw, degrees=False).as_quat()  # [qx, qy, qz, qw]
+        xformable.AddOrientOp().Set(Gf.Quatf(float(yaw_quat[3]), float(yaw_quat[0]), float(yaw_quat[1]), float(yaw_quat[2])))
 
         # Add the current person to the person manager
         PeopleManager.get_people_manager().add_person(self._stage_prefix, self)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -39,19 +39,16 @@ class Person:
     Class that implements a person in the simulation world. The person can be controlled by a controller that inherits from the PersonController class.
     """
 
-    # Get root assets path from setting, if not set, get the Isaac-Sim asset path
-    people_asset_folder = "https://omniverse-content-production.s3-us-west-2.amazonaws.com/Assets/Isaac/6.0/Isaac/People/Characters"
+    # Can be set by users to override the default NVIDIA asset server URL.
+    # When None, the path is resolved at runtime via get_assets_root_path() so
+    # the correct Nucleus/S3 URL for this Isaac Sim installation is used.
+    people_asset_folder = None
+
     # Default parent path for character prims (matches isaacsim.replicator.agent.core config default)
     character_root_prim_path = "/World/Characters"
 
-    assets_root_path = None   
-
-    if people_asset_folder:
-        assets_root_path = people_asset_folder
-    else:   
-        root_path = get_assets_root_path()
-        if root_path is not None:
-            assets_root_path  = "{}/Isaac/People/Characters".format(root_path)
+    # Resolved lazily on first Person instantiation (not at module import time)
+    assets_root_path = None
 
     def __init__(
         self, 
@@ -74,6 +71,18 @@ class Person:
 
         # Get the current stage
         self._current_stage = omni.usd.get_context().get_stage()
+
+        # Resolve assets root path lazily (carb settings are available by the time __init__ runs)
+        if Person.assets_root_path is None:
+            if Person.people_asset_folder:
+                Person.assets_root_path = Person.people_asset_folder
+            else:
+                try:
+                    root_path = get_assets_root_path()
+                    if root_path:
+                        Person.assets_root_path = f"{root_path}/Isaac/People/Characters"
+                except Exception as e:
+                    carb.log_error(f"Could not resolve Isaac Sim asset root path: {e}")
 
         # Variable that will hold the current state of the vehicle
         self._state = State()

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people/person.py
@@ -23,6 +23,9 @@ import isaacsim.core.experimental.utils.stage as stage_utils
 from isaacsim.core.simulation_manager import SimulationManager, SimulationEvent
 
 # New imports from the replicator API
+# omni.anim.graph.core is in extscache in Isaac Sim 6.0 and must be enabled before import
+from isaacsim.core.experimental.utils.app import enable_extension
+enable_extension("omni.anim.graph.core")
 import omni.anim.graph.core as ag
 import isaacsim.replicator.agent.core
 from isaacsim.replicator.agent.core.settings import PrimPaths

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/people_backends/ros2_people_backend.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/people_backends/ros2_people_backend.py
@@ -10,7 +10,7 @@ __all__ = ["ROS2PeopleBackend"]
 # Make sure the ROS2 extension is enabled
 import carb
 from pegasus.simulator.logic.people_backends.people_backend import PeopleBackend
-from isaacsim.core.utils.extensions import enable_extension
+from isaacsim.core.experimental.utils.app import enable_extension
 enable_extension("isaacsim.ros2.bridge")
 
 # ROS2 imports

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/multirotor.py
@@ -6,8 +6,10 @@
 """
 
 import numpy as np
+from pxr import UsdGeom
 
-from omni.isaac.dynamic_control import _dynamic_control
+import omni.usd
+from isaacsim.core.experimental.prims import Articulation
 
 # The vehicle interface
 from pegasus.simulator.logic.vehicles.vehicle import Vehicle
@@ -87,26 +89,30 @@ class Multirotor(Vehicle):
         self._thrusters = config.thrust_curve
         self._drag = config.drag
 
+        # Articulation handle — created lazily after simulation starts (physics tensor entity required)
+        self._articulation: Articulation | None = None
+        # Cache DOF indices for rotor joints keyed by rotor number
+        self._rotor_dof_indices: dict[int, int] = {}
+
     def start(self):
-        """In this case we do not need to do anything extra when the simulation starts"""
-        pass
+        """Set up the articulation handle when simulation starts."""
+        self._articulation = Articulation(paths=self._stage_prefix)
+        self._rotor_dof_indices = {}
 
     def stop(self):
-        """In this case we do not need to do anything extra when the simulation stops"""
-        pass
+        """Release the articulation handle when simulation stops."""
+        self._articulation = None
+        self._rotor_dof_indices = {}
 
-    def update(self, dt: float):
+    def update(self, dt: float, context=None):
         """
-        Method that computes and applies the forces to the vehicle in simulation based on the motor speed. 
-        This method must be implemented by a class that inherits this type. This callback
-        is called on every physics step.
+        Method that computes and applies the forces to the vehicle in simulation based on the motor speed.
+        This callback is called on every physics step.
 
         Args:
             dt (float): The time elapsed between the previous and current function calls (s).
+            context: Physics step context (unused, required by SimulationManager callback signature).
         """
-
-        # Get the articulation root of the vehicle
-        articulation = self.get_dc_interface().get_articulation(self._stage_prefix)
 
         # Get the desired angular velocities for each rotor from the first backend (can be mavlink or other) expressed in rad/s
         if len(self._backends) != 0:
@@ -127,7 +133,7 @@ class Multirotor(Vehicle):
             self.apply_force([0.0, 0.0, forces_z[i]], body_part="/rotor" + str(i))
 
             # Generate the rotating propeller visual effect
-            self.handle_propeller_visual(i, forces_z[i], articulation)
+            self.handle_propeller_visual(i, forces_z[i])
 
         # Apply the torque to the body frame of the vehicle that corresponds to the rolling moment
         self.apply_torque([0.0, 0.0, rolling_moment], "/body")
@@ -140,29 +146,50 @@ class Multirotor(Vehicle):
         for backend in self._backends:
             backend.update(dt)
 
-    def handle_propeller_visual(self, rotor_number, force: float, articulation):
+    def _get_rotor_dof_index(self, rotor_number: int) -> int | None:
+        """Return the cached DOF index for the given rotor joint, computing it on first use."""
+        if rotor_number in self._rotor_dof_indices:
+            return self._rotor_dof_indices[rotor_number]
+
+        if self._articulation is None:
+            return None
+
+        joint_name = "joint" + str(rotor_number)
+        try:
+            idx_array = self._articulation.get_dof_indices(joint_name)
+            idx = int(idx_array.numpy()[0])
+            self._rotor_dof_indices[rotor_number] = idx
+            return idx
+        except Exception:
+            return None
+
+    def handle_propeller_visual(self, rotor_number: int, force: float):
         """
-        Auxiliar method used to set the joint velocity of each rotor (for animation purposes) based on the 
-        amount of force being applied on each joint
+        Auxiliar method used to set the joint velocity of each rotor (for animation purposes) based on the
+        amount of force being applied on each joint.
 
         Args:
-            rotor_number (int): The number of the rotor to generate the rotation animation
-            force (float): The force that is being applied on that rotor
-            articulation (_type_): The articulation group the joints of the rotors belong to
+            rotor_number (int): The number of the rotor to generate the rotation animation.
+            force (float): The force that is being applied on that rotor.
         """
+        if self._articulation is None or not self._articulation.is_physics_tensor_entity_valid():
+            return
 
-        # Rotate the joint to yield the visual of a rotor spinning (for animation purposes only)
-        joint = self.get_dc_interface().find_articulation_dof(articulation, "joint" + str(rotor_number))
+        dof_idx = self._get_rotor_dof_index(rotor_number)
+        if dof_idx is None:
+            return
 
         # Spinning when armed but not applying force
         if 0.0 < force < 0.1:
-            self.get_dc_interface().set_dof_velocity(joint, 5 * self._thrusters.rot_dir[rotor_number])
+            velocity = 5.0 * self._thrusters.rot_dir[rotor_number]
         # Spinning when armed and applying force
         elif 0.1 <= force:
-            self.get_dc_interface().set_dof_velocity(joint, 100 * self._thrusters.rot_dir[rotor_number])
+            velocity = 100.0 * self._thrusters.rot_dir[rotor_number]
         # Not spinning
         else:
-            self.get_dc_interface().set_dof_velocity(joint, 0)
+            velocity = 0.0
+
+        self._articulation.set_dof_velocities([[velocity]], dof_indices=[dof_idx])
 
     def force_and_torques_to_velocities(self, force: float, torque: np.ndarray):
         """
@@ -179,30 +206,36 @@ class Multirotor(Vehicle):
         Returns:
             list: A list of angular velocities [rad/s] to apply in reach rotor to accomplish suchs forces and torques
         """
+        stage = omni.usd.get_context().get_stage()
+        xform_cache = UsdGeom.XformCache()
 
-        # Get the body frame of the vehicle
-        rb = self.get_dc_interface().get_rigid_body(self._stage_prefix + "/body")
+        body_prim = stage.GetPrimAtPath(self._stage_prefix + "/body")
+        body_world = xform_cache.GetLocalToWorldTransform(body_prim)
+        world_to_body = body_world.GetInverse()
 
-        # Get the rotors of the vehicle
-        rotors = [self.get_dc_interface().get_rigid_body(self._stage_prefix + "/rotor" + str(i)) for i in range(self._thrusters._num_rotors)]
+        # Get relative positions of rotor prims in the body frame
+        relative_positions = []
+        for i in range(self._thrusters._num_rotors):
+            rotor_prim = stage.GetPrimAtPath(self._stage_prefix + "/rotor" + str(i))
+            rotor_world = xform_cache.GetLocalToWorldTransform(rotor_prim)
+            rotor_in_body = rotor_world * world_to_body
+            translation = rotor_in_body.ExtractTranslation()
+            relative_positions.append([translation[0], translation[1], translation[2]])
 
-        # Get the relative position of the rotors with respect to the body frame of the vehicle (ignoring the orientation for now)
-        relative_poses = self.get_dc_interface().get_relative_body_poses(rb, rotors)
-
-        # Define the alocation matrix
+        # Define the allocation matrix
         aloc_matrix = np.zeros((4, self._thrusters._num_rotors))
-        
+
         # Define the first line of the matrix (T [N])
-        aloc_matrix[0, :] = np.array(self._thrusters._rotor_constant)                                           
+        aloc_matrix[0, :] = np.array(self._thrusters._rotor_constant)
 
         # Define the second and third lines of the matrix (\tau_x [Nm] and \tau_y [Nm])
-        aloc_matrix[1, :] = np.array([relative_poses[i].p[1] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
-        aloc_matrix[2, :] = np.array([-relative_poses[i].p[0] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
+        aloc_matrix[1, :] = np.array([relative_positions[i][1] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
+        aloc_matrix[2, :] = np.array([-relative_positions[i][0] * self._thrusters._rotor_constant[i] for i in range(self._thrusters._num_rotors)])
 
         # Define the forth line of the matrix (\tau_z [Nm])
         aloc_matrix[3, :] = np.array([self._thrusters._rolling_moment_coefficient[i] * self._thrusters._rot_dir[i] for i in range(self._thrusters._num_rotors)])
 
-        # Compute the inverse allocation matrix, so that we can get the angular velocities (squared) from the total thrust and torques
+        # Compute the inverse allocation matrix
         aloc_inv = np.linalg.pinv(aloc_matrix)
 
         # Compute the target angular velocities (squared)
@@ -219,7 +252,6 @@ class Multirotor(Vehicle):
 
         if max_val >= max_thrust_vel_squared:
             normalize = np.maximum(max_val / max_thrust_vel_squared, 1.0)
-
             squared_ang_vel = squared_ang_vel / normalize
 
         # Compute the angular velocities for each rotor in [rad/s]

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -11,14 +11,16 @@ from scipy.spatial.transform import Rotation
 
 # Low level APIs
 import carb
-from pxr import Usd, Gf
+from pxr import Usd, Gf, UsdGeom
 
 # High level Isaac sim APIs
 import omni.usd
-from isaacsim.core.utils.prims import define_prim, get_prim_at_path
 from omni.usd import get_stage_next_free_path
-from isaacsim.core.api.robots.robot import Robot
-from omni.isaac.dynamic_control import _dynamic_control
+import isaacsim.core.experimental.utils.app as app_utils
+import isaacsim.core.experimental.utils.stage as stage_utils
+from isaacsim.core.simulation_manager import SimulationManager, SimulationEvent
+from isaacsim.core.rendering_manager import RenderingManager, RenderingEvent
+from isaacsim.core.experimental.prims import RigidPrim
 
 # Extension APIs
 from pegasus.simulator.logic.state import State
@@ -43,8 +45,8 @@ def get_world_transform_xform(prim: Usd.Prim):
     return rotation
 
 
-class Vehicle(Robot):
-    
+class Vehicle:
+
     def __init__(
         self,
         stage_prefix: str,
@@ -66,9 +68,8 @@ class Vehicle(Robot):
             init_orientation (list): The initial orientation of the vehicle in quaternion [qx, qy, qz, qw]. Defaults to [0.0, 0.0, 0.0, 1.0].
         """
 
-        # Get the current world at which we want to spawn the vehicle
-        self._world = PegasusInterface().world
-        self._current_stage = self._world.stage
+        # Get the current stage
+        self._current_stage = omni.usd.get_context().get_stage()
 
         # Save the name with which the vehicle will appear in the stage
         # and the name of the .usd file that contains its description
@@ -79,26 +80,19 @@ class Vehicle(Robot):
         self._vehicle_name = self._stage_prefix.rpartition("/")[-1]
 
         # Spawn the vehicle primitive in the world's stage
-        self._prim = define_prim(self._stage_prefix, "Xform")
-        self._prim = get_prim_at_path(self._stage_prefix)
+        self._prim = stage_utils.define_prim(self._stage_prefix, "Xform")
+        self._prim = self._current_stage.GetPrimAtPath(self._stage_prefix)
         self._prim.GetReferences().AddReference(self._usd_file)
 
-        # Initialize the "Robot" class
-        # Note: we need to change the rotation to have qw first, because NVidia
-        # does not keep a standard of quaternions inside its own libraries (not good, but okay)
-        super().__init__(
-            prim_path=self._stage_prefix,
-            name=self._stage_prefix,
-            position=init_pos,
-            orientation=[init_orientation[3], init_orientation[0], init_orientation[1], init_orientation[2]],
-            articulation_controller=None,
-        )
+        # Set the initial pose via the Xform API
+        xformable = UsdGeom.Xformable(self._prim)
+        xformable.ClearXformOpOrder()
+        xformable.AddTranslateOp().Set(Gf.Vec3d(init_pos[0], init_pos[1], init_pos[2]))
+        # Convert [qx, qy, qz, qw] → [qw, qx, qy, qz] for USD/GfQuatd
+        xformable.AddOrientOp().Set(Gf.Quatd(init_orientation[3], init_orientation[0], init_orientation[1], init_orientation[2]))
 
-        self._vehicle_dc_interface = None
-
-        # Add this object for the world to track, so that if we clear the world, this object is deleted from memory and
-        # as a consequence, from the VehicleManager as well
-        self._world.scene.add(self)
+        # Body rigid prim — created lazily after simulation starts
+        self._body_rigid_prim: RigidPrim | None = None
 
         # Add the current vehicle to the vehicle manager, so that it knows
         # that a vehicle was instantiated
@@ -107,30 +101,27 @@ class Vehicle(Robot):
         # Variable that will hold the current state of the vehicle
         self._state = State()
 
-        # Add a callback to the physics engine to update the current state of the system
-        self._world.add_physics_callback(self._stage_prefix + "/state", self.update_state)
-
-        # Add the update method to the physics callback if the world was received
-        # so that we can apply forces and torques to the vehicle. Note, this method should        # be implemented in classes that inherit the vehicle object
-        self._world.add_physics_callback(self._stage_prefix + "/update", self.update)
+        # Register physics callbacks
+        self._cb_state = SimulationManager.register_callback(self.update_state, SimulationEvent.PHYSICS_POST_STEP)
+        self._cb_update = SimulationManager.register_callback(self.update, SimulationEvent.PHYSICS_POST_STEP)
 
         # Set the flag that signals if the simulation is running or not
         self._sim_running = False
 
-        # Add a callback to start/stop of the simulation once the play/stop button is hit
-        self._world.add_timeline_callback(self._stage_prefix + "/start_stop_sim", self.sim_start_stop)
+        # Register simulation start/stop callbacks
+        self._cb_sim_start = SimulationManager.register_callback(self._on_sim_started, SimulationEvent.SIMULATION_STARTED)
+        self._cb_sim_stop = SimulationManager.register_callback(self._on_sim_stopped, SimulationEvent.SIMULATION_STOPPED)
 
         # --------------------------------------------------------------------
         # -------------------- Add sensors to the vehicle --------------------
         # --------------------------------------------------------------------
         self._sensors = sensors
-        
+
         for sensor in self._sensors:
             sensor.initialize(self, PegasusInterface().latitude, PegasusInterface().longitude, PegasusInterface().altitude)
 
         # Add callbacks to the physics engine to update each sensor at every timestep
-        # and let the sensor decide depending on its internal update rate whether to generate new data
-        self._world.add_physics_callback(self._stage_prefix + "/Sensors", self.update_sensors)
+        self._cb_sensors = SimulationManager.register_callback(self.update_sensors, SimulationEvent.PHYSICS_POST_STEP)
 
         # --------------------------------------------------------------------
         # -------------------- Add the graphical sensors to the vehicle ------
@@ -140,9 +131,8 @@ class Vehicle(Robot):
         for graphical_sensor in self._graphical_sensors:
             graphical_sensor.initialize(self)
 
-        # Add callbacks to the rendering engine to update each graphical sensor at every timestep of the rendering engine
-        self._world.add_render_callback(self._stage_prefix + "/GraphicalSensors", self.update_graphical_sensors)
-
+        # Add callback to the rendering engine to update each graphical sensor
+        self._cb_render = RenderingManager.register_callback(RenderingEvent.NEW_FRAME, callback=self.update_graphical_sensors)
 
         # --------------------------------------------------------------------
         # -------------------- Add the graphs to the vehicle -----------------
@@ -151,7 +141,7 @@ class Vehicle(Robot):
 
         for graph in self._graphs:
             graph.initialize(self)
-        
+
         # --------------------------------------------------------------------
         # ---- Add (communication/control) backends to the vehicle -----------
         # --------------------------------------------------------------------
@@ -161,15 +151,27 @@ class Vehicle(Robot):
         for backend in self._backends:
             backend.initialize(self)
 
-        # Add a callbacks for the
-        self._world.add_physics_callback(self._stage_prefix + "/mav_state", self.update_sim_state)
+        # Callback for sending state to backends on every physics step
+        self._cb_sim_state = SimulationManager.register_callback(self.update_sim_state, SimulationEvent.PHYSICS_POST_STEP)
 
 
     def __del__(self):
         """
-        Method that is invoked when a vehicle object gets destroyed. When this happens, we also invoke the 
+        Method that is invoked when a vehicle object gets destroyed. When this happens, we also invoke the
         'remove_vehicle' from the VehicleManager in order to remove the vehicle from the list of active vehicles.
         """
+        # Deregister all SimulationManager callbacks
+        for cb_id in (self._cb_state, self._cb_update, self._cb_sensors, self._cb_sim_state,
+                      self._cb_sim_start, self._cb_sim_stop):
+            try:
+                SimulationManager.deregister_callback(cb_id)
+            except Exception:
+                pass
+        # Deregister RenderingManager callback
+        try:
+            RenderingManager.deregister_callback(self._cb_render)
+        except Exception:
+            pass
 
         # Remove this object from the vehicleHandler
         VehicleManager.get_vehicle_manager().remove_vehicle(self._stage_prefix)
@@ -179,6 +181,15 @@ class Vehicle(Robot):
     """
 
     @property
+    def prim_path(self) -> str:
+        """The USD stage path of this vehicle.
+
+        Returns:
+            str: Stage prefix string.
+        """
+        return self._stage_prefix
+
+    @property
     def state(self):
         """The state of the vehicle.
 
@@ -186,7 +197,7 @@ class Vehicle(Robot):
             State: The current state of the vehicle, i.e., position, orientation, linear and angular velocities...
         """
         return self._state
-    
+
     @property
     def vehicle_name(self) -> str:
         """Vehicle name.
@@ -200,17 +211,13 @@ class Vehicle(Robot):
     Operations
     """
 
-    def sim_start_stop(self, event):
-        """
-        Callback that is called every time there is a timeline event such as starting/stoping the simulation.
-
-        Args:
-            event: A timeline event generated from Isaac Sim, such as starting or stoping the simulation.
-        """
-
-        # If the start/stop button was pressed, then call the start and stop methods accordingly
-        if self._world.is_playing() and self._sim_running == False:
+    def _on_sim_started(self, *args):
+        """Callback invoked when the simulation starts (after the first physics warm-up step)."""
+        if not self._sim_running:
             self._sim_running = True
+
+            # Create (or re-create) the rigid prim wrapper now that physics is ready
+            self._body_rigid_prim = RigidPrim(paths=self._stage_prefix + "/body")
 
             # Initialize the sensors
             for sensor in self._sensors:
@@ -220,18 +227,19 @@ class Vehicle(Robot):
             for graphical_sensor in self._graphical_sensors:
                 graphical_sensor.start()
 
-            # Intializes the communication with all the backends. This method is invoked automatically when the simulation starts
+            # Initialize the communication backends
             for backend in self._backends:
                 backend.start()
 
-            # Invoke the start method of the vehicle (if it exists)
             self.start()
 
-        if self._world.is_stopped() and self._sim_running == True:
+    def _on_sim_stopped(self, *args):
+        """Callback invoked when the simulation stops."""
+        if self._sim_running:
             self._sim_running = False
 
-            # Reset the DC interface
-            self._vehicle_dc_interface = None
+            # Release the rigid prim wrapper so it can be re-created fresh on next play
+            self._body_rigid_prim = None
 
             # Stop the sensors
             for sensor in self._sensors:
@@ -241,7 +249,7 @@ class Vehicle(Robot):
             for graphical_sensor in self._graphical_sensors:
                 graphical_sensor.stop()
 
-            # Signal all the backends that the simulation has stoped. This method is invoked automatically when the simulation stops
+            # Signal all the backends that the simulation has stopped
             for backend in self._backends:
                 backend.stop()
 
@@ -250,70 +258,80 @@ class Vehicle(Robot):
     def apply_force(self, force, pos=[0.0, 0.0, 0.0], body_part="/body"):
         """
         Method that will apply a force on the rigidbody, on the part specified in the 'body_part' at its relative position
-        given by 'pos' (following a FLU) convention. 
+        given by 'pos' (following a FLU) convention.
 
         Args:
             force (list): A 3-dimensional vector of floats with the force [Fx, Fy, Fz] on the body axis of the vehicle according to a FLU convention.
-            pos (list): _description_. Defaults to [0.0, 0.0, 0.0].
-            body_part (str): . Defaults to "/body".
+            pos (list): Position offset in local body frame. Defaults to [0.0, 0.0, 0.0].
+            body_part (str): Rigid body sub-path relative to the vehicle stage prefix. Defaults to "/body".
         """
+        if self._body_rigid_prim is None or not self._body_rigid_prim.is_physics_tensor_entity_valid():
+            return
 
-        # Get the handle of the rigidbody that we will apply the force to
-        rb = self.get_dc_interface().get_rigid_body(self._stage_prefix + body_part)
+        prim_path = self._stage_prefix + body_part
+        rigid_prim = RigidPrim(paths=prim_path) if body_part != "/body" else self._body_rigid_prim
 
-        # Apply the force to the rigidbody. The force should be expressed in the rigidbody frame
-        self.get_dc_interface().apply_body_force(rb, carb._carb.Float3(force), carb._carb.Float3(pos), False)
+        forces = np.array([[force[0], force[1], force[2]]], dtype=np.float32)
+        torques = np.zeros((1, 3), dtype=np.float32)
+        positions = np.array([[pos[0], pos[1], pos[2]]], dtype=np.float32)
+        rigid_prim.apply_forces_and_torques_at_pos(forces=forces, torques=torques, positions=positions, local_frame=True)
 
     def apply_torque(self, torque, body_part="/body"):
         """
         Method that when invoked applies a given torque vector to /<rigid_body_name>/"body" or to /<rigid_body_name>/<body_part>.
 
         Args:
-            torque (list): A 3-dimensional vector of floats with the force [Tx, Ty, Tz] on the body axis of the vehicle according to a FLU convention.
-            body_part (str): . Defaults to "/body".
+            torque (list): A 3-dimensional vector of floats with the torque [Tx, Ty, Tz] on the body axis of the vehicle according to a FLU convention.
+            body_part (str): Rigid body sub-path relative to the vehicle stage prefix. Defaults to "/body".
         """
+        if self._body_rigid_prim is None or not self._body_rigid_prim.is_physics_tensor_entity_valid():
+            return
 
-        # Get the handle of the rigidbody that we will apply a torque to
-        rb = self.get_dc_interface().get_rigid_body(self._stage_prefix + body_part)
+        prim_path = self._stage_prefix + body_part
+        rigid_prim = RigidPrim(paths=prim_path) if body_part != "/body" else self._body_rigid_prim
 
-        # Apply the torque to the rigidbody. The torque should be expressed in the rigidbody frame
-        self.get_dc_interface().apply_body_torque(rb, carb._carb.Float3(torque), False)
+        forces = np.zeros((1, 3), dtype=np.float32)
+        torques = np.array([[torque[0], torque[1], torque[2]]], dtype=np.float32)
+        positions = np.zeros((1, 3), dtype=np.float32)
+        rigid_prim.apply_forces_and_torques_at_pos(forces=forces, torques=torques, positions=positions, local_frame=True)
 
-    def update_state(self, dt: float):
+    def update_state(self, dt: float, context=None):
         """
         Method that is called at every physics step to retrieve and update the current state of the vehicle, i.e., get
         the current position, orientation, linear and angular velocities and acceleration of the vehicle.
 
         Args:
             dt (float): The time elapsed between the previous and current function calls (s).
+            context: Physics step context (unused, required by SimulationManager callback signature).
         """
+        if self._body_rigid_prim is None:
+            return
 
-        # Get the body frame interface of the vehicle (this will be the frame used to get the position, orientation, etc.)
-        body = self.get_dc_interface().get_rigid_body(self._stage_prefix + "/body")
+        # Get the current position and orientation from the body rigid prim
+        # get_world_poses() returns (positions wp.array Nx3, orientations wp.array Nx4 in wxyz)
+        positions, orientations = self._body_rigid_prim.get_world_poses()
+        pos = positions.numpy()[0]        # [x, y, z]
+        quat_wxyz = orientations.numpy()[0]  # [qw, qx, qy, qz]
 
-        # Get the current position and orientation in the inertial frame
-        pose = self.get_dc_interface().get_rigid_body_pose(body)
-
-        # Get the attitude according to the convention [w, x, y, z]
-        prim = self._world.stage.GetPrimAtPath(self._stage_prefix + "/body")
+        # Get the attitude via the USD rotation (more accurate for orientation)
+        prim = self._current_stage.GetPrimAtPath(self._stage_prefix + "/body")
         rotation_quat = get_world_transform_xform(prim).GetQuaternion()
         rotation_quat_real = rotation_quat.GetReal()
         rotation_quat_img = rotation_quat.GetImaginary()
 
-        # Get the angular velocity of the vehicle expressed in the body frame of reference
-        ang_vel = self.get_dc_interface().get_rigid_body_angular_velocity(body)
-
-        # The linear velocity [x_dot, y_dot, z_dot] of the vehicle's body frame expressed in the inertial frame of reference
-        linear_vel = self.get_dc_interface().get_rigid_body_linear_velocity(body)
+        # Get the linear and angular velocities
+        # get_velocities() returns (linear wp.array Nx3, angular wp.array Nx3) both in world frame
+        linear_vels, angular_vels = self._body_rigid_prim.get_velocities()
+        linear_vel = linear_vels.numpy()[0]   # [vx, vy, vz] in world frame
+        ang_vel_world = angular_vels.numpy()[0]  # [wx, wy, wz] in world frame, rad/s
 
         # Get the linear acceleration of the body relative to the inertial frame, expressed in the inertial frame
-        # Note: we must do this approximation, since the Isaac sim does not output the acceleration of the rigid body directly
-        linear_acceleration = (np.array(linear_vel) - self._state.linear_velocity) / dt
+        linear_acceleration = (linear_vel - self._state.linear_velocity) / dt if dt > 0.0 else np.zeros(3)
 
         # Update the state variable X = [x,y,z]
-        self._state.position = np.array(pose.p)
+        self._state.position = np.array(pos)
 
-        # Get the quaternion according in the [qx,qy,qz,qw] standard
+        # Get the quaternion in the [qx, qy, qz, qw] standard
         self._state.attitude = np.array(
             [rotation_quat_img[0], rotation_quat_img[1], rotation_quat_img[2], rotation_quat_real]
         )
@@ -321,16 +339,15 @@ class Vehicle(Robot):
         # Express the velocity of the vehicle in the inertial frame X_dot = [x_dot, y_dot, z_dot]
         self._state.linear_velocity = np.array(linear_vel)
 
-        # The linear velocity V =[u,v,w] of the vehicle's body frame expressed in the body frame of reference
-        # Note that: x_dot = Rot * V
+        # The linear velocity V = [u,v,w] of the vehicle's body frame expressed in the body frame of reference
         self._state.linear_body_velocity = (
             Rotation.from_quat(self._state.attitude).inv().apply(self._state.linear_velocity)
         )
 
-        # omega = [p,q,r]
-        self._state.angular_velocity = Rotation.from_quat(self._state.attitude).inv().apply(np.array(ang_vel))
+        # omega = [p, q, r] expressed in body frame
+        self._state.angular_velocity = Rotation.from_quat(self._state.attitude).inv().apply(np.array(ang_vel_world))
 
-        # The acceleration of the vehicle expressed in the inertial frame X_ddot = [x_ddot, y_ddot, z_ddot]
+        # The acceleration of the vehicle expressed in the inertial frame
         self._state.linear_acceleration = linear_acceleration
 
     def start(self):
@@ -345,7 +362,7 @@ class Vehicle(Robot):
         """
         pass
 
-    def update(self, dt: float):
+    def update(self, dt: float, context=None):
         """
         Method that computes and applies the forces to the vehicle in
         simulation based on the motor speed. This method must be implemented
@@ -353,17 +370,18 @@ class Vehicle(Robot):
 
         Args:
             dt (float): The time elapsed between the previous and current function calls (s).
+            context: Physics step context (unused, required by SimulationManager callback signature).
         """
         pass
 
-    def update_sensors(self, dt: float):
+    def update_sensors(self, dt: float, context=None):
         """Callback that is called at every physics steps and will call the sensor.update method to generate new
         sensor data. For each data that the sensor generates, the backend.update_sensor method will also be called for
-        every backend. For example, if new data is generated for an IMU and we have a PX4MavlinkBackend, then the update_sensor
-        method will be called for that backend so that this data can latter be sent thorugh mavlink.
+        every backend.
 
         Args:
             dt (float): The time elapsed between the previous and current function calls (s).
+            context: Physics step context (unused, required by SimulationManager callback signature).
         """
 
         # Call the update method for the sensor to update its values internally (if applicable)
@@ -377,37 +395,32 @@ class Vehicle(Robot):
 
     def update_graphical_sensors(self, event):
         """Callback that is called at every rendering steps and will call the graphical_sensor.update method to generate new
-        sensor data. For each data that the sensor generates, the backend.update_graphical_sensor method will also be called for
-        every backend. For example, if new data is generated for a monocular camera and we have a ROS2Backend, then the update_graphical_sensor
-        method will be called for that backend so that this data can latter be sent through a ROS2 topic.
+        sensor data.
 
         Args:
-            event (float): The timer event that contains the time elapsed between the previous and current function calls (s).
+            event: Rendering event from RenderingManager.
         """
+        # Extract dt from the event payload if available, otherwise use a sensible default
+        dt = 1.0 / 60.0
+        if hasattr(event, 'payload') and isinstance(event.payload, dict):
+            dt = event.payload.get('dt', dt)
 
-        # Call the update method for the sensor to update its values internally (if applicable)
         for sensor in self._graphical_sensors:
-            sensor_data = sensor.update(self._state, event.payload['dt'])
+            sensor_data = sensor.update(self._state, dt)
 
             # If some data was updated and we have a ros backend (or other), then just update it
             if sensor_data is not None:
                 for backend in self._backends:
                     backend.update_graphical_sensor(sensor.sensor_type, sensor_data)
 
-    def update_sim_state(self, dt: float):
+    def update_sim_state(self, dt: float, context=None):
         """
         Callback that is used to "send" the current state for each backend being used to control the vehicle. This callback
         is called on every physics step.
 
         Args:
             dt (float): The time elapsed between the previous and current function calls (s).
+            context: Physics step context (unused, required by SimulationManager callback signature).
         """
         for backend in self._backends:
             backend.update_state(self._state)
-
-    def get_dc_interface(self):
-
-        if self._vehicle_dc_interface is None:
-            self._vehicle_dc_interface = _dynamic_control.acquire_dynamic_control_interface()
-
-        return self._vehicle_dc_interface

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -68,6 +68,10 @@ class Vehicle:
             init_orientation (list): The initial orientation of the vehicle in quaternion [qx, qy, qz, qw]. Defaults to [0.0, 0.0, 0.0, 1.0].
         """
 
+        # Initialize callback IDs to None so __del__ is safe even if __init__ fails partway
+        self._cb_state = self._cb_update = self._cb_sensors = self._cb_sim_state = None
+        self._cb_sim_start = self._cb_sim_stop = self._cb_render = None
+
         # Get the current stage
         self._current_stage = omni.usd.get_context().get_stage()
 
@@ -88,8 +92,8 @@ class Vehicle:
         xformable = UsdGeom.Xformable(self._prim)
         xformable.ClearXformOpOrder()
         xformable.AddTranslateOp().Set(Gf.Vec3d(init_pos[0], init_pos[1], init_pos[2]))
-        # Convert [qx, qy, qz, qw] → [qw, qx, qy, qz] for USD/GfQuatd
-        xformable.AddOrientOp().Set(Gf.Quatd(init_orientation[3], init_orientation[0], init_orientation[1], init_orientation[2]))
+        # Convert [qx, qy, qz, qw] → [qw, qx, qy, qz] for USD; use Quatf (single precision) to match the op type in NVIDIA USD assets
+        xformable.AddOrientOp().Set(Gf.Quatf(init_orientation[3], init_orientation[0], init_orientation[1], init_orientation[2]))
 
         # Body rigid prim — created lazily after simulation starts
         self._body_rigid_prim: RigidPrim | None = None
@@ -163,15 +167,17 @@ class Vehicle:
         # Deregister all SimulationManager callbacks
         for cb_id in (self._cb_state, self._cb_update, self._cb_sensors, self._cb_sim_state,
                       self._cb_sim_start, self._cb_sim_stop):
+            if cb_id is not None:
+                try:
+                    SimulationManager.deregister_callback(cb_id)
+                except Exception:
+                    pass
+        # Deregister RenderingManager callback
+        if self._cb_render is not None:
             try:
-                SimulationManager.deregister_callback(cb_id)
+                RenderingManager.deregister_callback(self._cb_render)
             except Exception:
                 pass
-        # Deregister RenderingManager callback
-        try:
-            RenderingManager.deregister_callback(self._cb_render)
-        except Exception:
-            pass
 
         # Remove this object from the vehicleHandler
         VehicleManager.get_vehicle_manager().remove_vehicle(self._stage_prefix)

--- a/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/logic/vehicles/vehicle.py
@@ -331,6 +331,11 @@ class Vehicle:
         linear_vel = linear_vels.numpy()[0]   # [vx, vy, vz] in world frame
         ang_vel_world = angular_vels.numpy()[0]  # [wx, wy, wz] in world frame, rad/s
 
+        # Convert warp float32 outputs to float64 so ROS 2 message fields pass PyFloat_Check
+        pos = pos.astype(np.float64)
+        linear_vel = linear_vel.astype(np.float64)
+        ang_vel_world = ang_vel_world.astype(np.float64)
+
         # Get the linear acceleration of the body relative to the inertial frame, expressed in the inertial frame
         linear_acceleration = (linear_vel - self._state.linear_velocity) / dt if dt > 0.0 else np.zeros(3)
 

--- a/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
+++ b/extensions/pegasus.simulator/pegasus/simulator/ui/ui_delegate.py
@@ -204,11 +204,8 @@ class UIDelegate:
         """
 
         async def async_load_vehicle():
-            # Check if we already have a physics environment activated. If not, then activate it
-            # and only after spawn the vehicle. This is to avoid trying to spawn a vehicle without a physics
-            # environment setup. This way we can even spawn a vehicle in an empty world and it won't care
-            if hasattr(self._pegasus_sim.world, "_physics_context") == False:
-                await self._pegasus_sim.world.initialize_simulation_context_async()
+            # Ensure physics dt is configured before spawning a vehicle
+            self._pegasus_sim.initialize_world()
 
             # Check if a vehicle is selected in the drop-down menu
             if self._vehicle_dropdown is not None and self._window is not None:

--- a/extensions/pegasus.simulator/setup.py
+++ b/extensions/pegasus.simulator/setup.py
@@ -85,7 +85,7 @@ setup(
     maintainer="Marcelo Jacinto",
     maintainer_email="marcelo.jacinto@tecnico.ulisboa.pt",
     url="https://github.com/PegasusSimulator/PegasusSimulator/tree/main/extensions/pegasus.simulator",
-    version="5.1.0",
+    version="6.0.0",
     description="Extension providing the main framework interfaces for simulating aerial vehicles using PX4, Python or ROS 2 as a backend",
     keywords=["drone", "quadrotor", "multirotor", "UAV", "px4", "sitl", "robotics"],
     license="BSD-3-Clause",


### PR DESCRIPTION
## Summary

This PR migrates PegasusSimulator from Isaac Sim 5.1 to 6.0, which removed all
`omni.isaac.*` extensions and significantly restructured the core simulation APIs.

## Breaking API changes addressed

- **`World` removed** → replaced with `SimulationManager` + `RenderingManager`
- **`Robot` base class removed** → plain Python class with manual USD prim creation
- **`omni.isaac.dynamic_control` removed** → `isaacsim.core.experimental.prims.RigidPrim`
  (returns `wp.array`; cast to `float64` for ROS 2 compatibility)
- **`omni.isaac.*` extension namespace removed** → `isaacsim.*` equivalents throughout
- **`read_camera_info`** moved to `isaacsim.ros2.core.impl.camera_info_utils`
- **People system** (`person.py`):
  - `omni.anim.graph.core` must be enabled explicitly in Isaac Sim 6.0
  - `PrimPaths` and `CharacterUtil` removed from `isaacsim.replicator.agent.core`
  - `Biped_Setup.usd` + `AnimationGraphAPI` replaced with `HumanMotionLibrary.usd` +
    `ApplyBehaviorAgentAPICommand` (must be deferred async to avoid OmniGraph segfault)
  - Asset root path resolved dynamically via `get_assets_root_path()` from
    `isaacsim.storage.native`
- **`GfQuatd` → `GfQuatf`** for `xformOp:orient` (NVIDIA USD assets use single-precision)
- **Examples**: removed hardcoded `/home/marcelo/PX4-Autopilot` paths — `px4_dir` now
  reads from `configs.yaml` via `PegasusInterface().px4_path`

## Tested

Validated against Isaac Sim 6.0.0 (`6.0.0-rc.59+release.41464`), ROS 2 Jazzy, PX4 (V1.16.0):

- `0_template_app.py` — simulation callbacks ✅
- `1_px4_single_vehicle.py` — PX4 SITL, drone connects to QGC and takes off ✅
- `3_ros2_single_vehicle.py` — ROS 2 backend, topics published correctly ✅
- `4_python_single_vehicle.py` — pure Python control ✅
- `9_people.py` — people spawning, NavMesh, animation ✅

# Closes Issues
* closes #143 